### PR TITLE
Add login to ghcr step to release workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,6 +28,12 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.IMAGE_PULL_TOKEN }}
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.4.0
         with:


### PR DESCRIPTION
## Description

The release workflow [recently failed](https://github.com/canonical/jimm-k8s-operator/actions/runs/9001080875/job/24727258922) with,
`Error response from daemon: Head "https://ghcr.io/v2/canonical/jimm/manifests/feature-oidc": unauthorized`

I neglected to add a `docker login` step to the release workflow since it now needs to pull the OCI image from the remote registry.