### PR TITLE
Update JIMM dep and add required config check

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -79,7 +79,7 @@ resources:
     type: oci-image
     description: OCI image for JIMM.
     # Update the below to a fixed version of JIMM once a stable release with OIDC is out.
-    upstream-source: ghcr.io/canonical/jimm:feature-oidc
+    upstream-source: ghcr.io/canonical/jimm:v3.1.0
   promtail-bin:
     type: file
     description: Promtail binary for logging

--- a/src/charm.py
+++ b/src/charm.py
@@ -75,6 +75,7 @@ REQUIRED_SETTINGS = {
     "OPENFGA_SCHEME": "missing openfga relation",
     "OPENFGA_TOKEN": "missing openfga relation",
     "OPENFGA_PORT": "missing openfga relation",
+    "JIMM_DASHBOARD_FINAL_REDIRECT_URL": "mising final-redirect-url configuration",
     "BAKERY_PRIVATE_KEY": "missing private key configuration",
     "BAKERY_PUBLIC_KEY": "missing public key configuration",
 }


### PR DESCRIPTION
## Description

This PR updates the JIMM version used by the charm to v3.1.0.
Also a minor tweak to the charm code to ensure the dashboard redirect URL config option is provided as the workfload required this value.

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests
