### PR TITLE
Update oauth client config

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -702,7 +702,7 @@ class JimmOperatorCharm(CharmBase):
             redirect_uri=urljoin(dns, "/auth/callback"),
             scope=OAUTH_SCOPES,
             grant_types=OAUTH_GRANT_TYPES,
-            token_endpoint_auth_method="client_secret_post"
+            token_endpoint_auth_method="client_secret_post",
         )
 
     def get_vault_nonce(self) -> str:


### PR DESCRIPTION
## Description

This PR ensures the OAuth client we create can pass its client-secret in the body rather than header. When trying to start the device flow JIMM was reporting an error:
```
Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The OAuth 2.0 Client supports client authentication method 'client_secret_basic', but method 'client_secret_post' was requested. You must configure the OAuth 2.0 client's 'token_endpoint_auth_method' value to accept 'client_secret_post'.
```
This is because JIMM passes the client secret via the body of the message rather than the header which is what Hydra expects by default.

The details on Hydra are described [here](https://www.ory.sh/docs/hydra/debug/token-endpoint-auth-method)

Solved thanks for the conversation [here](https://matrix.to/#/!nRbdoDYxdQndEfzlJi:ubuntu.com/$aVSucvC4gaUV3EwpAgJO7s2i3GA42ULmofQ7329A5oU?via=ubuntu.com&via=matrix.org&via=mozilla.org).

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
Tested by packing the charm and using it locally, device code flow works successfully.