### PR TITLE
Update promote.yaml

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -17,8 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 #v4.1.6
       - name: Release charm to channel
-        uses: canonical/charming-actions/promote-charm@33627add534483f7d5bd83fff736a9330db3b4f8 # 2.6.0
+        uses: canonical/charming-actions/promote-charm@19db2e9c9da186f64b38b95d8e7e57229f3362da # 2.6.0
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           destination-channel: ${{ github.event.inputs.destination-channel }}
           origin-channel: ${{ github.event.inputs.origin-channel }}


### PR DESCRIPTION
## Description

Fix the promote-charm workflow. The [documentation page](https://github.com/canonical/charming-actions/tree/main/promote-charm) incorrectly mentions that the github-token is not a required parameter, but running the action revealed that it is.

Also, there was a fix to the workflow and it looks like they tagged it with the same version so I've updated the commit SHA but the comment remains the same.