### PR TITLE
Use github_token for pulling JIMM image

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,8 +13,6 @@ on:
 jobs:
   charm-tests:
     uses: ./.github/workflows/test.yaml
-    secrets:
-      IMAGE_PULL_TOKEN: ${{ secrets.IMAGE_PULL_TOKEN }}
 
   release-charm:
     name: Release charm
@@ -33,7 +31,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.IMAGE_PULL_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@934193396735701141a1decc3613818e412da606 # 2.6.3
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,9 +1,6 @@
 name: Charm Test
 on:
   workflow_call:
-    secrets:
-      IMAGE_PULL_TOKEN:
-        required: true
   workflow_dispatch:
   pull_request:
 
@@ -62,7 +59,7 @@ jobs:
           read -r -d '' REGISTRY_CONFIG << EOL || true
             [plugins."io.containerd.grpc.v1.cri".registry.configs."ghcr.io".auth]
               username = "${{ github.actor }}"
-              password = "${{ secrets.IMAGE_PULL_TOKEN }}"
+              password = "${{ secrets.GITHUB_TOKEN }}"
           EOL
           echo "$REGISTRY_CONFIG" | sudo tee -a /var/snap/microk8s/current/args/containerd-template.toml
           sudo snap restart microk8s.daemon-containerd


### PR DESCRIPTION
## Description

This PR removes the need for the `IMAGE_PULL_TOKEN` from workflows.

Now that the JIMM repo is public, we don't need a separate secret to access the package. The GITHUB_TOKEN has the necessary permissions.

This is also useful as this repo should also be made public and with less secrets there is less difficulty for contributions.
