### PR TITLE
use consistent format for dashboard relation

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -419,8 +419,8 @@ class JimmOperatorCharm(CharmBase):
         if dashboard_relation and self.unit.is_leader():
             dashboard_relation.data[self.app].update(
                 {
-                    "controller_url": "wss://{}".format(dns_name),
-                    "is_juju": str(False),
+                    "controller-url": "wss://{}".format(dns_name),
+                    "is-juju": str(False),
                 }
             )
 
@@ -509,8 +509,8 @@ class JimmOperatorCharm(CharmBase):
 
         event.relation.data[self.app].update(
             {
-                "controller_url": "wss://{}".format(dns_name),
-                "is_juju": str(False),
+                "controller-url": "wss://{}".format(dns_name),
+                "is-juju": str(False),
             }
         )
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -462,10 +462,10 @@ class TestCharm(TestCase):
 
         self.assertTrue(data)
         self.assertEqual(
-            data["controller_url"],
+            data["controller-url"],
             "wss://jimm.localhost",
         )
-        self.assertEqual(data["is_juju"], "False")
+        self.assertEqual(data["is-juju"], "False")
 
     def test_vault_relation_joined(self):
         self.use_fake_session_secret()


### PR DESCRIPTION
## Description

The Juju dashboard charm supports both `is-juju` and `is_juju` (and the same for controller_url) as values in the relation data bag because the JIMM charm would return `is_juju` while the [Juju charm](https://github.com/juju/juju-controller/blob/3.1/src/charm.py#L43) returns `is-juju`. Switch to do the same thing as the Juju charm.

This fixes some annoying code that can be seen in https://github.com/canonical/juju-dashboard-charm/pull/33

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests