### PR TITLE
test errors with 2 units

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -855,14 +855,28 @@ class JimmOperatorCharm(CharmBase):
             "Pulling trusted ca certificates from %s relation.",
             self.trusted_cert_transfer.relationship_name,
         )
-        for relation in self.model.relations.get(self.trusted_cert_transfer.relationship_name, []):
-            # here relation.units is empty for non-leader units
-            for unit in set(relation.units).difference([self.app, self.unit]):
-                # Note: this nested loop handles the case of multi-unit CA, each unit providing
-                # a different ca cert, but that is not currently supported by the lib itself.
-                cert_path = TRUSTED_CA_TEMPLATE.substitute(rel_id=relation.id)
-                if cert := relation.data[unit].get("ca"):
-                    container.push(cert_path, cert, make_dirs=True)
+        certs = []
+        if self.unit.is_leader():
+            for relation in self.model.relations.get(self.trusted_cert_transfer.relationship_name, []):
+                for unit in set(relation.units).difference([self.app, self.unit]):
+                    # Note: this nested loop handles the case of multi-unit CA, each unit providing
+                    # a different ca cert, but that is not currently supported by the lib itself.
+                    cert_path = TRUSTED_CA_TEMPLATE.substitute(rel_id=relation.id)
+                    if cert := relation.data[unit].get("ca"):
+                        certs.append([cert_path, cert])
+            # set certs in peer relation databag, if they are changed
+            if certs:
+                existing_certs_secret = json.loads(self.model.get_relation("peer").data[self.app].get("ca", "[]"))
+                certs_json = json.dumps(certs)
+                if existing_certs_secret != certs_json:
+                    self.model.get_relation("peer").data[self.app]["ca"] = certs_json
+        else:
+            # in non-leader units read data from the relation databag
+            certs = json.loads(self.model.get_relation("peer").data[self.app].get("ca", "[]"))
+
+        # now push certs in the containers
+        for [cert_path, cert] in certs:
+            container.push(cert_path, cert, make_dirs=True)
 
         stdout, stderr = container.exec(["update-ca-certificates", "--fresh"]).wait_output()
         logger.info("stdout update-ca-certificates: %s", stdout)

--- a/src/charm.py
+++ b/src/charm.py
@@ -856,7 +856,7 @@ class JimmOperatorCharm(CharmBase):
             self.trusted_cert_transfer.relationship_name,
         )
         for relation in self.model.relations.get(self.trusted_cert_transfer.relationship_name, []):
-            # For some reason, relation.units includes our unit and app. Need to exclude them.
+            # here relation.units is empty for non-leader units
             for unit in set(relation.units).difference([self.app, self.unit]):
                 # Note: this nested loop handles the case of multi-unit CA, each unit providing
                 # a different ca cert, but that is not currently supported by the lib itself.

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -71,6 +71,7 @@ async def deploy_jimm(
                     # to one of HTTP endpoints of JIMM.
                     "juju-dashboard-location": os.path.join(jimm_address.geturl(), "debug/info"),
                 },
+                num_units=2,
             ),
             ops_test.model.deploy("nginx-ingress-integrator", application_name="jimm-ingress", channel="latest/stable"),
             ops_test.model.deploy(
@@ -110,7 +111,6 @@ async def deploy_jimm(
 
     logger.info("adding oauth relation")
     await ops_test.model.integrate(f"{APP_NAME}:oauth", hydra_app_name)
-
     await ops_test.model.wait_for_idle(timeout=2000)
     jimm_debug_info = requests.get(os.path.join(jimm_address.geturl(), "debug/info"))
     assert jimm_debug_info.status_code == 200


### PR DESCRIPTION
## Description

I have found an issue, where if you scale the jimm charm to two units the second unit is in an error state.
The reason is that it doesn't receive the ca-cert, so it is not able to contact hydra.
The fix is to set the ca in the peer relation databag, so non-leader unit can read the ca cert as well

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->
