### PR TITLE
chore: update jimm image

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -94,5 +94,5 @@ resources:
     type: oci-image
     description: OCI image for JIMM.
     # Update the below to a fixed version of JIMM once a stable release with OIDC is out.
-    upstream-source: ghcr.io/canonical/jimm:v3.2.0
+    upstream-source: ghcr.io/canonical/jimm:v3.2.3
 


### PR DESCRIPTION
## Description

This PR updates the JIMM image to the latest release v3.2.2 specifically to bring in changes from https://github.com/canonical/jimm/pull/1569 that ensure the server can shutdown gracefully.