### PR TITLE
feat: improve openfga connection handling

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -826,12 +826,7 @@ class JimmOperatorCharm(CharmBase):
         client = OpenFGAClient(info.http_api_url, info.store_id, token=info.token, verify=False)
         local_model = json.loads(auth_model)
 
-        # If the auth model is already set, compare with remote and skip if unchanged
-        # The auth model has the following structure:
-        # {
-        #   "schema_version": "1.0",
-        #   "type_definitions": [...]
-        # }
+        # If the auth model already exists, we skip creation.
         auth_model_id = self._state.openfga_auth_model_id
         if auth_model_id:
             logger.info("checking existing OpenFGA authorization model")
@@ -841,17 +836,8 @@ class JimmOperatorCharm(CharmBase):
                 logger.error("failed to fetch existing authorization model: %s", e)
                 logger.warning("skipping auth model creation")
                 return
-            if not remote:
-                logger.error("failed to fetch existing authorization model")
-                return
-            remote_model = remote.get("authorization_model")
-            if not remote_model:
-                logger.error("response does not contain authorization model")
-                return
-            is_same_schema = remote_model.get("schema_version") == local_model.get("schema_version")
-            is_same_types = remote_model.get("type_definitions") == local_model.get("type_definitions")
-            if is_same_schema and is_same_types:
-                logger.info("OpenFGA authorisation model unchanged; skipping creation")
+            if remote is not None:
+                logger.info("found OpenFGA authorisation model; skipping creation")
                 return
 
         # Create/Update the authorization model

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,6 +2,7 @@
 # This file is part of the JIMM k8s Charm for Juju.
 # Copyright 2024 Canonical Ltd.
 
+import hashlib
 import json
 import logging
 import os
@@ -826,8 +827,9 @@ class JimmOperatorCharm(CharmBase):
         client = OpenFGAClient(info.http_api_url, info.store_id, token=info.token, verify=False)
         local_model = json.loads(auth_model)
 
-        # If the auth model already exists, we skip creation.
+        # First check if the auth model already exists in OpenFGA.
         auth_model_id = self._state.openfga_auth_model_id
+        auth_model_exists = False
         if auth_model_id:
             logger.info("checking existing OpenFGA authorization model")
             try:
@@ -837,8 +839,17 @@ class JimmOperatorCharm(CharmBase):
                 logger.warning("skipping auth model creation")
                 return
             if remote is not None:
-                logger.info("found OpenFGA authorisation model; skipping creation")
-                return
+                logger.info("found OpenFGA authorisation model")
+                auth_model_exists = True
+
+        # Compare auth model from the image with the one in the state
+        # See https://github.com/openfga/openfga/issues/2277 for more info.
+        model_hash = hashlib.new("md5")
+        model_hash.update(auth_model.encode())
+        digest = model_hash.hexdigest()
+        if auth_model_exists and self._state.openfga_auth_model_digest == digest:
+            logger.info("OpenFGA authorisation model already exists and is up to date")
+            return
 
         # Create/Update the authorization model
         logger.info("OpenFGA authorisation model changed; updating")
@@ -852,6 +863,7 @@ class JimmOperatorCharm(CharmBase):
             logger.error("response does not contain authorization model id")
             raise ValueError("response does not contain authorization model id")
         self._state.openfga_auth_model_id = authorization_model_id
+        self._state.openfga_auth_model_digest = digest
 
     @property
     def _oauth_client_config(self) -> ClientConfig:

--- a/src/charm.py
+++ b/src/charm.py
@@ -834,21 +834,34 @@ class JimmOperatorCharm(CharmBase):
         # }
         auth_model_id = self._state.openfga_auth_model_id
         if auth_model_id:
+            logger.info("checking existing OpenFGA authorization model")
             try:
                 remote = client.get_authorization_model(auth_model_id)
             except ValueError as e:
                 logger.error("failed to fetch existing authorization model: %s", e)
                 logger.warning("skipping auth model creation")
                 return
-            remote_model = remote.get("authorization_model", remote) if remote else None
-            is_same_schema = remote_model and remote_model.get("schema_version") == local_model.get("schema_version")
-            is_same_types = remote_model and remote_model.get("type_definitions") == local_model.get("type_definitions")
+            if not remote:
+                logger.error("failed to fetch existing authorization model")
+                return
+            remote_model = remote.get("authorization_model")
+            if not remote_model:
+                logger.error("response does not contain authorization model")
+                return
+            is_same_schema = remote_model.get("schema_version") == local_model.get("schema_version")
+            is_same_types = remote_model.get("type_definitions") == local_model.get("type_definitions")
             if is_same_schema and is_same_types:
                 logger.info("OpenFGA authorisation model unchanged; skipping creation")
                 return
 
         # Create/Update the authorization model
-        authorization_model_id = client.create_authorization_model(local_model)
+        logger.info("OpenFGA authorisation model changed; updating")
+        try:
+            authorization_model_id = client.create_authorization_model(local_model)
+        except ValueError as e:
+            logger.warning("failed to create OpenFGA authorisation model: %s", e)
+            logger.warning("skipping auth model creation; will retry on next event")
+            return
         if not authorization_model_id:
             logger.error("response does not contain authorization model id")
             raise ValueError("response does not contain authorization model id")

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,6 @@
 # This file is part of the JIMM k8s Charm for Juju.
 # Copyright 2024 Canonical Ltd.
 
-import hashlib
 import json
 import logging
 import os
@@ -11,7 +10,6 @@ import string
 from base64 import b64encode
 from urllib.parse import urljoin, urlparse
 
-import requests
 from charms.certificate_transfer_interface.v0.certificate_transfer import (
     CertificateRemovedEvent,
     CertificateTransferRequires,
@@ -68,6 +66,7 @@ from ops.model import (
     WaitingStatus,
 )
 
+from openfga_client import OpenFGAClient
 from state import State, requires_state, requires_state_setter
 
 logger = logging.getLogger(__name__)
@@ -335,6 +334,7 @@ class JimmOperatorCharm(CharmBase):
             event.defer()
             return
 
+        # Wait for OAuth relations
         self.oauth.update_client_config(client_config=self._oauth_client_config)
         if not self.oauth.is_client_created():
             logger.warning("OAuth relation is not ready yet")
@@ -342,10 +342,19 @@ class JimmOperatorCharm(CharmBase):
             self._stop()
             return
 
+        # Wait for database relation
         if not self.database.is_resource_created():
             logger.warning("database relation is not ready yet")
             self.unit.status = BlockedStatus("Waiting for database relation")
             return
+
+        # Wait for OpenFGA relations
+        openfga_info = self.openfga.get_store_info()
+        if not openfga_info:
+            logger.warning("OpenFGA relation is not ready yet")
+            self.unit.status = BlockedStatus("Waiting for OpenFGA relation")
+            return
+        openfga_url_details = urlparse(openfga_info.http_api_url)
 
         self.setup_fga_auth_model(container)
 
@@ -355,6 +364,10 @@ class JimmOperatorCharm(CharmBase):
             return
 
         oauth_provider_info = self.oauth.get_provider_info()
+        if not oauth_provider_info:
+            logger.warning("OAuth provider info is not ready yet")
+            self.unit.status = BlockedStatus("Waiting for OAuth provider info")
+            return
         known_scopes = set(OAUTH_SCOPES.split(" "))
         oauth_provider_scopes = set(oauth_provider_info.scope.split(" "))
         scopes = " ".join(sorted(oauth_provider_scopes.intersection(known_scopes)))
@@ -388,12 +401,12 @@ class JimmOperatorCharm(CharmBase):
             "JIMM_UUID": self.config.get("uuid", ""),
             "JIMM_DASHBOARD_LOCATION": self.config.get("juju-dashboard-location", "https://jaas.ai/models"),
             "JIMM_LISTEN_ADDR": ":8080",
-            "OPENFGA_STORE": self._state.openfga_store_id,
+            "OPENFGA_STORE": openfga_info.store_id,
             "OPENFGA_AUTH_MODEL": self._state.openfga_auth_model_id,
-            "OPENFGA_HOST": self._state.openfga_address,
-            "OPENFGA_SCHEME": self._state.openfga_scheme,
-            "OPENFGA_TOKEN": self._state.openfga_token,
-            "OPENFGA_PORT": self._state.openfga_port,
+            "OPENFGA_HOST": openfga_url_details.hostname,
+            "OPENFGA_SCHEME": openfga_url_details.scheme,
+            "OPENFGA_TOKEN": openfga_info.token,
+            "OPENFGA_PORT": openfga_url_details.port,
             "BAKERY_PRIVATE_KEY": self.config.get("private-key", ""),
             "BAKERY_PUBLIC_KEY": self.config.get("public-key", ""),
             "JIMM_DSN": self._make_database_dsn(),
@@ -659,21 +672,6 @@ class JimmOperatorCharm(CharmBase):
 
     @requires_state_setter
     def _on_openfga_store_created(self, event: OpenFGAStoreCreateEvent) -> None:
-        if not event.store_id:
-            return
-
-        info = self.openfga.get_store_info()
-        if not info:
-            logger.warning("openfga info not ready yet")
-            return
-
-        self._state.openfga_store_id = info.store_id
-        self._state.openfga_token = info.token
-        o = urlparse(info.http_api_url)
-        self._state.openfga_address = o.hostname
-        self._state.openfga_port = o.port
-        self._state.openfga_scheme = o.scheme
-
         self._update_workload(event)
 
     @requires_state
@@ -806,69 +804,62 @@ class JimmOperatorCharm(CharmBase):
 
         model_path = "/root/openfga/authorisation_model.json"
         try:
-            model = jimm_container.pull(model_path).read()
+            auth_model = jimm_container.pull(model_path).read()
         except pebble.PathError:
             logger.warning("auth model not found at %s", model_path)
             raise LookupError("Failed to find auth model in JIMM's OCI image")
 
-        if not model:
+        if not auth_model:
             raise ValueError("empty auth model found")
 
-        model_hash = hashlib.new("md5")
-        model_hash.update(model.encode())
-        digest = model_hash.hexdigest()
-
-        if digest == self._state.openfga_auth_model_hash:
-            logger.info("auth model already exists, won't recreate")
+        info = self.openfga.get_store_info()
+        if not info:
+            logger.warning("openfga is not ready yet, skipping auth model creation")
             return
 
-        model_json = json.loads(model)
-
-        openfga_store_id = self._state.openfga_store_id
-        openfga_token = self._state.openfga_token
-        openfga_address = self._state.openfga_address
-        openfga_port = self._state.openfga_port
-        openfga_scheme = self._state.openfga_scheme
-
-        if not openfga_address or not openfga_port or not openfga_scheme or not openfga_token or not openfga_store_id:
-            logger.info("openfga is not ready yet, skipping auth model creation")
+        # Ensure store_id exists before continuing
+        if not info.store_id:
+            logger.warning("openfga store_id not available yet; skipping auth model setup")
             return
 
-        url = "{}://{}:{}/stores/{}/authorization-models".format(
-            openfga_scheme,
-            openfga_address,
-            openfga_port,
-            openfga_store_id,
-        )
-        headers = {"Content-Type": "application/json"}
-        if openfga_token:
-            headers["Authorization"] = "Bearer {}".format(openfga_token)
+        # Use client for OpenFGA interactions
+        client = OpenFGAClient(info.http_api_url, info.store_id, token=info.token, verify=False)
+        local_model = json.loads(auth_model)
 
-        # do the post request
-        logger.info("posting to {}, with headers {}".format(url, headers))
-        response = requests.post(
-            url,
-            json=model_json,
-            headers=headers,
-            verify=False,
-        )
-        if not response.ok:
-            logger.error("failed to create authorisation model - %s", response.text)
-            raise ValueError("failed to create authorisation model")
-        data = response.json()
-        authorization_model_id = data.get("authorization_model_id", "")
+        # If the auth model is already set, compare with remote and skip if unchanged
+        # The auth model has the following structure:
+        # {
+        #   "schema_version": "1.0",
+        #   "type_definitions": [...]
+        # }
+        auth_model_id = self._state.openfga_auth_model_id
+        if auth_model_id:
+            try:
+                remote = client.get_authorization_model(auth_model_id)
+            except ValueError as e:
+                logger.error("failed to fetch existing authorization model: %s", e)
+                logger.warning("skipping auth model creation")
+                return
+            remote_model = remote.get("authorization_model", remote) if remote else None
+            is_same_schema = remote_model and remote_model.get("schema_version") == local_model.get("schema_version")
+            is_same_types = remote_model and remote_model.get("type_definitions") == local_model.get("type_definitions")
+            if is_same_schema and is_same_types:
+                logger.info("OpenFGA authorisation model unchanged; skipping creation")
+                return
+
+        # Create/Update the authorization model
+        authorization_model_id = client.create_authorization_model(local_model)
         if not authorization_model_id:
-            logger.error("response does not contain authorization model id - %s", response.text)
+            logger.error("response does not contain authorization model id")
             raise ValueError("response does not contain authorization model id")
         self._state.openfga_auth_model_id = authorization_model_id
-        self._state.openfga_auth_model_hash = digest
 
     @property
     def _oauth_client_config(self) -> ClientConfig:
         dns = self.config.get("dns-name")
         if dns is None or dns == "":
             dns = "http://localhost"
-        dns = ensureFQDN(dns)
+        dns = ensureFQDN(str(dns))
         return ClientConfig(
             redirect_uri=urljoin(dns, "/auth/callback"),
             scope=OAUTH_SCOPES,

--- a/src/openfga_client.py
+++ b/src/openfga_client.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import requests
+
+
+class OpenFGAClient:
+    """Simple client for interacting with OpenFGA HTTP API for authorization models.
+
+    This client only implements the minimal subset required by the charm:
+    - Create an authorization model
+    - Get an authorization model by ID
+    """
+
+    def __init__(self, base_url: str, store_id: str, token: str | None = None, verify: bool = False):
+        self.base_url = base_url.rstrip("/")
+        self.store_id = store_id
+        self.token = token
+        self.verify = verify
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        return headers
+
+    def create_authorization_model(self, model: dict) -> str:
+        """Create a new authorization model.
+
+        Args:
+            model: A dict representing the authorization model payload.
+
+        Returns:
+            The created authorization model ID.
+
+        Raises:
+            ValueError: If the request fails or the response is missing the model ID.
+        """
+        url = f"{self.base_url}/stores/{self.store_id}/authorization-models"
+        resp = requests.post(url, json=model, headers=self._headers, verify=self.verify)
+        if not resp.ok:
+            raise ValueError(f"failed to create authorisation model - {resp.text}")
+        data = resp.json()
+        model_id = data.get("authorization_model_id")
+        if not model_id:
+            raise ValueError("response does not contain authorization model id")
+        return model_id
+
+    def get_authorization_model(self, model_id: str) -> dict | None:
+        """Fetch an authorization model by ID.
+
+        Args:
+            model_id: The authorization model ID.
+
+        Returns:
+            The authorization model as a dict, or None if not found (404).
+
+        Raises:
+            ValueError: If the request fails with a non-404 error.
+        """
+        url = f"{self.base_url}/stores/{self.store_id}/authorization-models/{model_id}"
+        resp = requests.get(url, headers=self._headers, verify=self.verify)
+        if resp.status_code == 404:
+            return None
+        if not resp.ok:
+            raise ValueError(f"failed to fetch authorisation model - {resp.text}")
+        return resp.json()

--- a/src/openfga_client.py
+++ b/src/openfga_client.py
@@ -37,7 +37,10 @@ class OpenFGAClient:
             ValueError: If the request fails or the response is missing the model ID.
         """
         url = f"{self.base_url}/stores/{self.store_id}/authorization-models"
-        resp = requests.post(url, json=model, headers=self._headers, verify=self.verify)
+        try:
+            resp = requests.post(url, json=model, headers=self._headers, verify=self.verify)
+        except requests.exceptions.RequestException as e:
+            raise ValueError(f"failed to create authorisation model - {e}") from e
         if not resp.ok:
             raise ValueError(f"failed to create authorisation model - {resp.text}")
         data = resp.json()
@@ -59,7 +62,10 @@ class OpenFGAClient:
             ValueError: If the request fails with a non-404 error.
         """
         url = f"{self.base_url}/stores/{self.store_id}/authorization-models/{model_id}"
-        resp = requests.get(url, headers=self._headers, verify=self.verify)
+        try:
+            resp = requests.get(url, headers=self._headers, verify=self.verify)
+        except requests.exceptions.RequestException as e:
+            raise ValueError(f"failed to fetch authorisation model - {e}") from e
         if resp.status_code == 404:
             return None
         if not resp.ok:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -590,7 +590,7 @@ class TestCharm(TestCase):
 
     @mock.patch("src.openfga_client.requests.post")
     @mock.patch("src.openfga_client.requests.get")
-    def test_setup_fga_auth_model_recreated_when_different(self, mock_get, mock_post):
+    def test_setup_fga_auth_model_recreated_when_missing(self, mock_get, mock_post):
         # Prepare the local model file with minimal content
         self.harness.enable_hooks()
         local_model = {"schema_version": "1.1", "type_definitions": []}
@@ -610,9 +610,8 @@ class TestCharm(TestCase):
                 def json(self):
                     return self.json_data
 
-            # Different type definitions should trigger a model update
-            remote_model = {"schema_version": "1.1", "type_definitions": ["foo"]}
-            return MockResponse({"authorization_model": remote_model}, 200)
+            # 404 should trigger a model creation
+            return MockResponse({}, 404)
 
         mock_get.side_effect = mocked_requests_get
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -80,6 +80,11 @@ BASE_ENV = {
     "JIMM_SECURE_SESSION_COOKIES": True,
     "JIMM_SESSION_COOKIE_MAX_AGE": 86400,
     "JIMM_SESSION_SECRET_KEY": "test-secret",
+    "OPENFGA_HOST": "openfga.localhost",
+    "OPENFGA_PORT": 8080,
+    "OPENFGA_SCHEME": "http",
+    "OPENFGA_STORE": "fake-store-id",
+    "OPENFGA_TOKEN": "fake-token",
 }
 
 # The environment may optionally include Vault.
@@ -146,6 +151,18 @@ class TestCharm(TestCase):
 
         self.add_oauth_relation()
 
+    # Helper to write the fake OpenFGA model file used by tests
+    def _write_openfga_model(self, model: object) -> pathlib.Path:
+        root = self.harness.get_filesystem_root(WORKLOAD_CONTAINER)
+        dir_path = root / "root" / "openfga"
+        dir_path.mkdir(parents=True, exist_ok=True)
+        file_path = dir_path / "authorisation_model.json"
+        if isinstance(model, str):
+            file_path.write_text(model)
+        else:
+            file_path.write_text(json.dumps(model))
+        return file_path
+
     def use_fake_host_key(self):
         patcher = mock.patch("src.charm.new_host_key", return_value={HOST_KEY_LOOKUP: fixed_host_key})
         patcher.start()
@@ -154,6 +171,12 @@ class TestCharm(TestCase):
     def use_fake_session_secret(self):
         patcher = mock.patch("src.charm.new_session_key", return_value={SESSION_KEY_LOOKUP: "test-secret"})
         self.mock_key = patcher.start()
+        self.fake_session_secret_patcher = patcher
+        self.addCleanup(patcher.stop)
+
+    def use_fake_setup_fga_model(self):
+        patcher = mock.patch("src.charm.JimmOperatorCharm.setup_fga_auth_model", return_value=None)
+        patcher.start()
         self.addCleanup(patcher.stop)
 
     def add_openfga_relation(self):
@@ -224,10 +247,8 @@ class TestCharm(TestCase):
         )
 
     def create_auth_model_info(self):
-        root = self.harness.get_filesystem_root(WORKLOAD_CONTAINER)
-        dir_path = root / "root" / "openfga"
-        dir_path.mkdir(parents=True)
-        (dir_path / "authorisation_model.json").write_text("null")
+        # Write a minimal model file and set initial state
+        self._write_openfga_model("null")
         self.harness.charm._state.openfga_auth_model_hash = "37a6259cc0c1dae299a7866489dff0bd"
         self.harness.charm._state.openfga_auth_model_id = 1
 
@@ -237,6 +258,9 @@ class TestCharm(TestCase):
 
     def start_minimal_jimm(self):
         self.harness.enable_hooks()
+        self.use_fake_session_secret()
+        self.use_fake_host_key()
+        self.use_fake_setup_fga_model()
         self.create_auth_model_info()
         self.add_openfga_relation()
         self.add_vault_relation()
@@ -271,13 +295,7 @@ class TestCharm(TestCase):
         self.assertEqual(self.harness.charm._state.chain, ["chain"])
 
     def test_on_pebble_ready(self):
-        self.use_fake_session_secret()
-        self.use_fake_host_key()
-        self.harness.enable_hooks()
-        self.create_auth_model_info()
-        self.add_vault_relation()
-        self.add_postgres_relation()
-        self.harness.update_config(MINIMAL_CONFIG)
+        self.start_minimal_jimm()
 
         container = self.harness.model.unit.get_container("jimm")
         # Emit the pebble-ready event for jimm
@@ -294,15 +312,10 @@ class TestCharm(TestCase):
         self.assertEqual(self.harness.charm.unit.status.message, "Waiting for OAuth relation")
 
     def test_on_config_changed(self):
-        self.use_fake_session_secret()
-        self.use_fake_host_key()
-        self.harness.enable_hooks()
-        self.create_auth_model_info()
-        self.add_vault_relation()
-        self.add_postgres_relation()
+        self.start_minimal_jimm()
+
         container = self.harness.model.unit.get_container("jimm")
         self.harness.charm.on.jimm_pebble_ready.emit(container)
-
         self.harness.update_config(MINIMAL_CONFIG)
         self.harness.set_leader(True)
 
@@ -334,12 +347,8 @@ class TestCharm(TestCase):
         )
 
     def test_postgres_secret_storage_config(self):
-        self.use_fake_session_secret()
-        self.use_fake_host_key()
-        self.ensure_jimm_secrets()
-        self.create_auth_model_info()
-        self.add_postgres_relation()
-        self.harness.update_config(MINIMAL_CONFIG)
+        self.start_minimal_jimm()
+
         self.harness.update_config({"postgres-secret-storage": True})
         container = self.harness.model.unit.get_container("jimm")
         self.harness.charm.on.jimm_pebble_ready.emit(container)
@@ -352,15 +361,10 @@ class TestCharm(TestCase):
     def test_proxy_settings(
         self,
     ):
+        self.start_minimal_jimm()
         os.environ["JUJU_CHARM_NO_PROXY"] = "no-proxy.canonincal.com"
         os.environ["JUJU_CHARM_HTTP_PROXY"] = "http-proxy.canonincal.com"
         os.environ["JUJU_CHARM_HTTPS_PROXY"] = "https-proxy.canonincal.com"
-        self.use_fake_session_secret()
-        self.use_fake_host_key()
-        self.ensure_jimm_secrets()
-        self.create_auth_model_info()
-        self.add_postgres_relation()
-        self.harness.update_config(MINIMAL_CONFIG)
         self.harness.update_config({"postgres-secret-storage": True})
         container = self.harness.model.unit.get_container("jimm")
         self.harness.charm.on.jimm_pebble_ready.emit(container)
@@ -378,10 +382,8 @@ class TestCharm(TestCase):
         os.environ["JUJU_CHARM_HTTPS_PROXY"] = ""
 
     def test_dashboard_config(self):
-        self.create_auth_model_info()
-        self.harness.enable_hooks()
-        self.add_vault_relation()
-        self.add_postgres_relation()
+        self.start_minimal_jimm()
+
         self.harness.update_config(
             {
                 **MINIMAL_CONFIG,
@@ -396,16 +398,12 @@ class TestCharm(TestCase):
             "JIMM_DASHBOARD_LOCATION": "https://some.host",
             "JIMM_DASHBOARD_FINAL_REDIRECT_URL": "https://some.host",
         }
-        self.assertDictEqual(
-            plan.to_dict()["services"]["jimm"]["environment"],
-            plan.to_dict()["services"]["jimm"]["environment"] | expected_values,
-        )
+        plan_dict = plan.to_dict()
+        env = plan_dict.get("services", {}).get(JIMM_SERVICE_NAME, {}).get("environment", {})
+        self.assertDictEqual(env, env | expected_values)
 
     def test_ssh_config(self):
-        self.create_auth_model_info()
-        self.harness.enable_hooks()
-        self.add_vault_relation()
-        self.add_postgres_relation()
+        self.start_minimal_jimm()
         self.harness.update_config(
             {
                 **MINIMAL_CONFIG,
@@ -420,10 +418,9 @@ class TestCharm(TestCase):
             "JIMM_SSH_PORT": 22,
             "JIMM_SSH_MAX_CONCURRENT_CONNECTIONS": 101,
         }
-        self.assertDictEqual(
-            new_plan.to_dict()["services"]["jimm"]["environment"],
-            new_plan.to_dict()["services"]["jimm"]["environment"] | expected_values,
-        )
+        new_plan_dict = new_plan.to_dict()
+        new_env = new_plan_dict.get("services", {}).get(JIMM_SERVICE_NAME, {}).get("environment", {})
+        self.assertDictEqual(new_env, new_env | expected_values)
 
     def test_app_dns_address(self):
         self.harness.update_config(MINIMAL_CONFIG)
@@ -469,23 +466,13 @@ class TestCharm(TestCase):
         self.assertEqual(self.harness.charm.unit.status.message, "Waiting for OAuth relation")
 
     def test_audit_log_retention_config(self):
-        self.use_fake_session_secret()
-        self.use_fake_host_key()
-        self.harness.enable_hooks()
-        self.create_auth_model_info()
-        self.add_vault_relation()
-        self.add_postgres_relation()
-        container = self.harness.model.unit.get_container("jimm")
-        self.harness.charm.on.jimm_pebble_ready.emit(container)
+        self.start_minimal_jimm()
 
-        self.harness.update_config(MINIMAL_CONFIG)
         self.harness.update_config({"audit-log-retention-period-in-days": "10"})
 
-        # Emit the pebble-ready event for jimm
-        self.harness.charm.on.jimm_pebble_ready.emit(container)
+        # Check the that the plan was updated
         expected_env = EXPECTED_VAULT_ENV.copy()
         expected_env.update({"JIMM_AUDIT_LOG_RETENTION_PERIOD_IN_DAYS": "10"})
-        # Check the that the plan was updated
         plan = self.harness.get_container_pebble_plan("jimm")
         self.assertEqual(plan.to_dict(), get_expected_plan(expected_env))
 
@@ -517,40 +504,29 @@ class TestCharm(TestCase):
         self.assertEqual(data["is-juju"], "False")
 
     def test_vault_relation_joined(self):
-        self.use_fake_session_secret()
-        self.use_fake_host_key()
-        self.create_auth_model_info()
-        self.harness.enable_hooks()
-        self.add_vault_relation()
-        self.add_postgres_relation()
+        self.start_minimal_jimm()
 
-        self.harness.update_config(MINIMAL_CONFIG)
         plan = self.harness.get_container_pebble_plan("jimm")
         self.assertEqual(plan.to_dict(), get_expected_plan(EXPECTED_VAULT_ENV))
 
     def test_app_blocked_without_private_key(self):
-        self.harness.enable_hooks()
-        # Setup the OpenFGA relation.
-        self.create_auth_model_info()
-        self.add_openfga_relation()
-        self.add_vault_relation()
-        self.add_postgres_relation()
-        self.harness.charm._state.openfga_auth_model_id = 1
-        # Set the config with the private-key value missing.
+        self.start_minimal_jimm()
+
         min_config_no_private_key = MINIMAL_CONFIG.copy()
-        del min_config_no_private_key["private-key"]
+        min_config_no_private_key["private-key"] = ""
         self.harness.update_config(min_config_no_private_key)
         self.assertEqual(self.harness.charm.unit.status.name, BlockedStatus.name)
         self.assertEqual(
             self.harness.charm.unit.status.message,
             "BAKERY_PRIVATE_KEY configuration value not set: missing private key configuration",
         )
+
         # Now check that we can get the app into an active state.
         self.harness.update_config(MINIMAL_CONFIG)
         self.assertEqual(self.harness.charm.unit.status.name, ActiveStatus.name)
         self.assertEqual(self.harness.charm.unit.status.message, "running")
 
-    @mock.patch("src.charm.requests.post")
+    @mock.patch("src.openfga_client.requests.post")
     def test_setup_fga_auth_model(self, mock_post):
         def mocked_requests_post(*args, **kwargs):
             class MockResponse:
@@ -566,41 +542,111 @@ class TestCharm(TestCase):
 
         mock_post.side_effect = mocked_requests_post
         self.harness.enable_hooks()
-        root = self.harness.get_filesystem_root(WORKLOAD_CONTAINER)
-        dir_path = root / "root" / "openfga"
-        dir_path.mkdir(parents=True)
-        (dir_path / "authorisation_model.json").write_text("null")
-        self.add_openfga_relation()
-        self.add_postgres_relation()
-        self.assertEqual(self.harness.charm._state.openfga_auth_model_id, 123)
-        self.assertNotEqual(self.harness.charm._state.openfga_auth_model_hash, "")
+        # Write a minimal model
+        self._write_openfga_model("null")
 
-    def test_setup_fga_auth_model_skipped_when_auth_model_exists(self):
+        self.add_openfga_relation()
+        container = self.harness.model.unit.get_container(WORKLOAD_CONTAINER)
+        self.harness.charm.setup_fga_auth_model(container)
+
+        # Ensure the authorization model was created and stored
+        self.assertEqual(self.harness.charm._state.openfga_auth_model_id, 123)
+        self.assertTrue(mock_post.called)
+
+    @mock.patch("src.openfga_client.requests.post")
+    @mock.patch("src.openfga_client.requests.get")
+    def test_setup_fga_auth_model_skipped_when_auth_model_exists(self, mock_get, mock_post):
+        # Prepare the local model file with minimal valid content
         self.harness.enable_hooks()
-        root = self.harness.get_filesystem_root(WORKLOAD_CONTAINER)
-        dir_path = root / "root" / "openfga"
-        dir_path.mkdir(parents=True)
-        (dir_path / "authorisation_model.json").write_text("null")
-        self.harness.charm._state.openfga_auth_model_hash = "37a6259cc0c1dae299a7866489dff0bd"
-        with self.assertLogs() as cm:
-            self.add_openfga_relation()
-            self.add_postgres_relation()
-            found = False
-            for line in cm.output:
-                found |= "auth model already exists, won't recreate" in line
-            self.assertTrue(found)
-        self.assertEqual(self.harness.charm._state.openfga_auth_model_id, None)
+        local_model = {"schema_version": "1.1", "type_definitions": []}
+        self._write_openfga_model(local_model)
+
+        # Set an existing model id in state to trigger the comparison path
+        self.harness.charm._state.openfga_auth_model_id = "existing-id"
+
+        # Mock GET to return an equivalent remote model (wrapped like OpenFGA)
+        def mocked_requests_get(*args, **kwargs):
+            class MockResponse:
+                def __init__(self, json_data, status_code):
+                    self.json_data = json_data
+                    self.status_code = status_code
+                    self.ok = True
+
+                def json(self):
+                    return self.json_data
+
+            # Return the remote payload with the same schema and types
+            return MockResponse({"authorization_model": local_model}, 200)
+
+        mock_get.side_effect = mocked_requests_get
+
+        self.add_openfga_relation()
+        container = self.harness.model.unit.get_container(WORKLOAD_CONTAINER)
+        self.harness.charm.setup_fga_auth_model(container)
+
+        mock_post.assert_not_called()
+        # Existing id should remain unchanged
+        self.assertEqual(self.harness.charm._state.openfga_auth_model_id, "existing-id")
+
+    @mock.patch("src.openfga_client.requests.post")
+    @mock.patch("src.openfga_client.requests.get")
+    def test_setup_fga_auth_model_recreated_when_different(self, mock_get, mock_post):
+        # Prepare the local model file with minimal content
+        self.harness.enable_hooks()
+        local_model = {"schema_version": "1.1", "type_definitions": []}
+        self._write_openfga_model(local_model)
+
+        # Existing model id in state to trigger comparison path
+        self.harness.charm._state.openfga_auth_model_id = "existing-id"
+
+        # Mock GET to return a different remote model to force a create
+        def mocked_requests_get(*args, **kwargs):
+            class MockResponse:
+                def __init__(self, json_data, status_code):
+                    self.json_data = json_data
+                    self.status_code = status_code
+                    self.ok = True
+
+                def json(self):
+                    return self.json_data
+
+            # Different type definitions should trigger a model update
+            remote_model = {"schema_version": "1.1", "type_definitions": ["foo"]}
+            return MockResponse({"authorization_model": remote_model}, 200)
+
+        mock_get.side_effect = mocked_requests_get
+
+        # Mock POST to return a new model id
+        def mocked_requests_post(*args, **kwargs):
+            class MockResponse:
+                def __init__(self, json_data, status_code):
+                    self.json_data = json_data
+                    self.status_code = status_code
+                    self.ok = True
+
+                def json(self):
+                    return self.json_data
+
+            return MockResponse({"authorization_model_id": "new-id"}, 200)
+
+        mock_post.side_effect = mocked_requests_post
+
+        self.add_openfga_relation()
+        container = self.harness.model.unit.get_container(WORKLOAD_CONTAINER)
+        self.harness.charm.setup_fga_auth_model(container)
+
+        # Ensure POST was called and the state updated to the new id
+        self.assertTrue(mock_post.called)
+        self.assertEqual(self.harness.charm._state.openfga_auth_model_id, "new-id")
 
     def test_session_secret_length(self):
         secret_dict = new_session_key()
         self.assertTrue(len(secret_dict[SESSION_KEY_LOOKUP]) >= 64)
 
     def test_rotate_session_key_action(self):
-        self.harness.enable_hooks()
-        self.create_auth_model_info()
-        self.add_vault_relation()
-        self.add_postgres_relation()
-        self.harness.update_config(MINIMAL_CONFIG)
+        # Stop the fake session secret patcher to test the secret rotation.
+        self.start_minimal_jimm()
+        self.fake_session_secret_patcher.stop()
 
         container = self.harness.model.unit.get_container("jimm")
         self.harness.charm.on.jimm_pebble_ready.emit(container)
@@ -615,11 +661,7 @@ class TestCharm(TestCase):
         self.assertNotEqual(old_session_secret, new_session_secret)
 
     def test_default_host_key_is_valid(self):
-        self.harness.enable_hooks()
-        self.create_auth_model_info()
-        self.add_vault_relation()
-        self.add_postgres_relation()
-        self.harness.update_config(MINIMAL_CONFIG)
+        self.start_minimal_jimm()
 
         container = self.harness.model.unit.get_container("jimm")
         self.harness.charm.on.jimm_pebble_ready.emit(container)
@@ -629,11 +671,7 @@ class TestCharm(TestCase):
         self.assertTrue(is_valid_private_key(old_session_secret))
 
     def test_set_host_key_config(self):
-        self.harness.enable_hooks()
-        self.create_auth_model_info()
-        self.add_openfga_relation()
-        self.add_vault_relation()
-        self.add_postgres_relation()
+        self.start_minimal_jimm()
 
         # Set the config as a new secret
         host_key = new_host_key()[HOST_KEY_LOOKUP]
@@ -651,11 +689,8 @@ class TestCharm(TestCase):
         self.assertEqual(self.harness.charm.unit.status.name, ActiveStatus.name)
 
     def test_set_host_key_config_invalid_key(self):
-        self.harness.enable_hooks()
-        self.create_auth_model_info()
-        self.add_openfga_relation()
-        self.add_vault_relation()
-        self.add_postgres_relation()
+        self.start_minimal_jimm()
+
         # Set the config as a new secret
         secret_id = self.harness.add_user_secret({"hostkey": "invalid-key"})
         self.harness.grant_secret(secret_id, "juju-jimm-k8s")
@@ -669,11 +704,7 @@ class TestCharm(TestCase):
         self.assertEqual(self.harness.charm.unit.status.message, "hostkey retrieval failed. Check juju debug logs.")
 
     def test_change_host_key_secret_content(self):
-        self.harness.enable_hooks()
-        self.create_auth_model_info()
-        self.add_openfga_relation()
-        self.add_vault_relation()
-        self.add_postgres_relation()
+        self.start_minimal_jimm()
 
         # Set the config as a new secret
         host_key = new_host_key()[HOST_KEY_LOOKUP]
@@ -695,26 +726,19 @@ class TestCharm(TestCase):
 
     @mock.patch.object(ops.model.Unit, "is_leader")
     def test_rotate_session_key_action_non_leader(self, is_leader):
+        self.start_minimal_jimm()
+
+        # Set is_leader to return false to mimic a non-leader unit.
         is_leader.return_value = False
-        self.harness.enable_hooks()
-        self.create_auth_model_info()
-        self.add_vault_relation()
-        self.harness.update_config(MINIMAL_CONFIG)
         with self.assertRaises(ActionFailed) as e:
             self.harness.run_action("rotate-session-key")
         self.assertEqual(e.exception.message, "Run this action on the leader unit")
 
     @mock.patch.object(ops.model.Unit, "is_leader")
     def test_plan_on_non_leader(self, is_leader):
-        self.use_fake_session_secret()
-        self.use_fake_host_key()
-        # Ensure we are leader in order to create the secret.
         is_leader.return_value = True
-        self.harness.enable_hooks()
-        self.create_auth_model_info()
-        self.add_vault_relation()
-        self.add_postgres_relation()
-        self.harness.update_config(MINIMAL_CONFIG)
+        self.start_minimal_jimm()
+
         container = self.harness.model.unit.get_container("jimm")
         # Set is_leader to return false to mimic a non-leader unit.
         is_leader.return_value = False
@@ -733,14 +757,8 @@ class TestCharm(TestCase):
             self.assertRegex(subnet, r"^([0-9]{1,3}\.){3}[0-9]{1,3}($|/(\d{2}))$")
 
     def test_cors_allowed_origins(self):
-        self.use_fake_session_secret()
-        self.use_fake_host_key()
-        self.create_auth_model_info()
-        self.harness.enable_hooks()
-        self.add_vault_relation()
-        self.add_postgres_relation()
+        self.start_minimal_jimm()
 
-        self.harness.update_config(MINIMAL_CONFIG)
         self.harness.update_config({"cors-allowed-origins": "http://test.localhost"})
         plan = self.harness.get_container_pebble_plan("jimm")
         expected_env = EXPECTED_VAULT_ENV.copy()
@@ -758,5 +776,5 @@ class TestCharm(TestCase):
         self.assertEqual(
             self.harness.charm.unit.get_container(WORKLOAD_CONTAINER).get_service(JIMM_SERVICE_NAME).is_running(), False
         )
-        self.assertEqual(self.harness.charm.unit._status.message, "Waiting for OAuth relation")
-        self.assertEqual(self.harness.charm.unit._status.name, "blocked")
+        self.assertEqual(self.harness.charm.unit.status.message, "Waiting for OAuth relation")
+        self.assertEqual(self.harness.charm.unit.status.name, "blocked")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,6 +5,7 @@
 
 
 import copy
+import hashlib
 import json
 import os
 import pathlib
@@ -558,13 +559,13 @@ class TestCharm(TestCase):
     def test_setup_fga_auth_model_skipped_when_auth_model_exists(self, mock_get, mock_post):
         # Prepare the local model file with minimal valid content
         self.harness.enable_hooks()
-        local_model = {"schema_version": "1.1", "type_definitions": []}
-        self._write_openfga_model(local_model)
+        auth_model = {"schema_version": "1.1", "type_definitions": []}
+        self._write_openfga_model(auth_model)
 
         # Set an existing model id in state to trigger the comparison path
         self.harness.charm._state.openfga_auth_model_id = "existing-id"
 
-        # Mock GET to return an equivalent remote model (wrapped like OpenFGA)
+        # Mock GET to return an equivalent remote model
         def mocked_requests_get(*args, **kwargs):
             class MockResponse:
                 def __init__(self, json_data, status_code):
@@ -576,9 +577,13 @@ class TestCharm(TestCase):
                     return self.json_data
 
             # Return the remote payload with the same schema and types
-            return MockResponse({"authorization_model": local_model}, 200)
+            return MockResponse(auth_model, 200)
 
         mock_get.side_effect = mocked_requests_get
+
+        # Compute the digest of the remote model and set it on state
+        remote_digest = hashlib.md5(json.dumps(auth_model, sort_keys=True).encode("utf-8")).hexdigest()
+        self.harness.charm._state.openfga_auth_model_digest = remote_digest
 
         self.add_openfga_relation()
         container = self.harness.model.unit.get_container(WORKLOAD_CONTAINER)
@@ -587,6 +592,60 @@ class TestCharm(TestCase):
         mock_post.assert_not_called()
         # Existing id should remain unchanged
         self.assertEqual(self.harness.charm._state.openfga_auth_model_id, "existing-id")
+
+    @mock.patch("src.openfga_client.requests.post")
+    @mock.patch("src.openfga_client.requests.get")
+    def test_setup_fga_auth_model_recreated_when_auth_model_changes(self, mock_get, mock_post):
+        # Prepare the local model file with minimal valid content
+        self.harness.enable_hooks()
+        auth_model = {"schema_version": "1.1", "type_definitions": []}
+        self._write_openfga_model(auth_model)
+
+        # Set an existing model id in state to trigger the comparison path
+        self.harness.charm._state.openfga_auth_model_id = "existing-id"
+
+        # Mock GET to return a remote model
+        def mocked_requests_get(*args, **kwargs):
+            class MockResponse:
+                def __init__(self, json_data, status_code):
+                    self.json_data = json_data
+                    self.status_code = status_code
+                    self.ok = True
+
+                def json(self):
+                    return self.json_data
+
+            # Return the remote payload with the same schema and types
+            return MockResponse(auth_model, 200)
+
+        mock_get.side_effect = mocked_requests_get
+
+        # Mock POST to return a new model id
+        def mocked_requests_post(*args, **kwargs):
+            class MockResponse:
+                def __init__(self, json_data, status_code):
+                    self.json_data = json_data
+                    self.status_code = status_code
+                    self.ok = True
+
+                def json(self):
+                    return self.json_data
+
+            return MockResponse({"authorization_model_id": "new-id"}, 200)
+
+        mock_post.side_effect = mocked_requests_post
+
+        # Set a fake digest that won't match the local model
+        # This simulates a change in the model that requires recreation
+        self.harness.charm._state.openfga_auth_model_digest = "fake-digest"
+
+        self.add_openfga_relation()
+        container = self.harness.model.unit.get_container(WORKLOAD_CONTAINER)
+        self.harness.charm.setup_fga_auth_model(container)
+
+        # Ensure POST was called and the state updated to the new id
+        self.assertTrue(mock_post.called)
+        self.assertEqual(self.harness.charm._state.openfga_auth_model_id, "new-id")
 
     @mock.patch("src.openfga_client.requests.post")
     @mock.patch("src.openfga_client.requests.get")


### PR DESCRIPTION
## Description

This PR started with a similar reason as https://github.com/canonical/jimm-k8s-operator/pull/81, where JIMM would always use stale data from its peer relation instead of fetching the latest connection details from the app relation (see the linked issue for more details).

In addition to the above, the JIMM charm was creating a hash of the desired OpenFGA auth model and comparing that with the value in its state. If the two matched, JIMM would not recreate the auth model if OpenFGA, expecting that if it exists in the charm's state, it must exist in OpenFGA. But in the current JIMM deployment, the database was recreated so the auth model no longer exists in OpenFGA. This PR adjusts JIMM's logic to rather check OpenFGA instead of relying on its own permanent cache.

Fixes [JUJU-8386](https://warthogs.atlassian.net/browse/JUJU-8386)

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

[JUJU-8386]: https://warthogs.atlassian.net/browse/JUJU-8386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ