### PR TITLE
fix: correct openfga client logic

### DIFF
--- a/src/openfga_client.py
+++ b/src/openfga_client.py
@@ -56,7 +56,7 @@ class OpenFGAClient:
             model_id: The authorization model ID.
 
         Returns:
-            The authorization model as a dict, or None if not found (404).
+            The authorization model as a dict, or None if not found (OpenFGA error code).
 
         Raises:
             ValueError: If the request fails with a non-404 error.
@@ -66,8 +66,12 @@ class OpenFGAClient:
             resp = requests.get(url, headers=self._headers, verify=self.verify)
         except requests.exceptions.RequestException as e:
             raise ValueError(f"failed to fetch authorisation model - {e}") from e
-        if resp.status_code == 404:
-            return None
         if not resp.ok:
+            try:
+                error_data = resp.json()
+                if error_data.get("code") == "authorization_model_not_found":
+                    return None
+            except requests.exceptions.JSONDecodeError:
+                pass
             raise ValueError(f"failed to fetch authorisation model - {resp.text}")
         return resp.json()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -670,7 +670,9 @@ class TestCharm(TestCase):
                     return self.json_data
 
             # The specific error code should trigger a model creation
-            return MockResponse({"code":"authorization_model_not_found","message":"Authorization Model 'fake-model' not found"}, 400)
+            return MockResponse(
+                {"code": "authorization_model_not_found", "message": "Authorization Model 'fake-model' not found"}, 400
+            )
 
         mock_get.side_effect = mocked_requests_get
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -658,19 +658,19 @@ class TestCharm(TestCase):
         # Existing model id in state to trigger comparison path
         self.harness.charm._state.openfga_auth_model_id = "existing-id"
 
-        # Mock GET to return a different remote model to force a create
+        # Mock GET to return a missing "error" message to force a create
         def mocked_requests_get(*args, **kwargs):
             class MockResponse:
                 def __init__(self, json_data, status_code):
                     self.json_data = json_data
                     self.status_code = status_code
-                    self.ok = True
+                    self.ok = False
 
                 def json(self):
                     return self.json_data
 
-            # 404 should trigger a model creation
-            return MockResponse({}, 404)
+            # The specific error code should trigger a model creation
+            return MockResponse({"code":"authorization_model_not_found","message":"Authorization Model 'fake-model' not found"}, 400)
 
         mock_get.side_effect = mocked_requests_get
 


### PR DESCRIPTION
## Description

This PR fixes logic added in https://github.com/canonical/jimm-k8s-operator/pull/82 where we were calling OpenFGA to check if the authorisation model exists yet. The client logic was incorrect as OpenFGA doesn't return a 404 when the resource is not found, a 404 is returned on invalid paths see https://openfga.dev/api/service#/Authorization%20Models/ReadAuthorizationModel. This PR corrects that logic. In our development environment we get the body `{\"code\":\"authorization_model_not_found\",\"message\":\"Authorization Model '01JE957M5XNSWXT8XC7DVH6PAD' not found\"}` back.

I briefly considered bringing in the official [OpenFGA Python SDK](https://github.com/openfga/python-sdk) but that has its own problems that need to be worked out (the lib is async so we need to add `await` and I can't remember how charm code handles the use of async handlers).

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests