### PR TITLE
chore: update to latest cert-transfer lib

### DIFF
--- a/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
@@ -4,7 +4,15 @@
 """Library for the certificate_transfer relation.
 
 This library contains the Requires and Provides classes for handling the
-certificate-transfer interface.
+certificate-transfer interface. It supports both v0 and v1 of the interface.
+
+For requirers, they will set version 1 in their application databag as a hint to
+the provider. They will read the databag from the provider first as v1, and fallback
+to v0 if the format does not match.
+
+For providers, they will check the version in the requirer's application databag,
+and send v1 if that version is set to 1, otherwise it will default to 0 for backwards
+compatibility.
 
 ## Getting Started
 From a charm directory, fetch the library using `charmcraft`:
@@ -94,6 +102,7 @@ import json
 import logging
 from typing import List, MutableMapping, Optional, Set
 
+import pydantic
 from ops import (
     CharmEvents,
     EventBase,
@@ -102,10 +111,10 @@ from ops import (
     Relation,
     RelationBrokenEvent,
     RelationChangedEvent,
+    RelationCreatedEvent,
 )
 from ops.charm import CharmBase
 from ops.framework import Object
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 # The unique Charmhub library identifier, never change it
 LIBID = "3785165b24a743f2b0c60de52db25c8b"
@@ -115,7 +124,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 12
 
 logger = logging.getLogger(__name__)
 
@@ -130,81 +139,176 @@ class DataValidationError(TLSCertificatesError):
     """Raised when data validation fails."""
 
 
-class DatabagModel(BaseModel):
-    """Base databag model."""
+if int(pydantic.version.VERSION.split(".")[0]) < 2:
 
-    model_config = ConfigDict(
-        # tolerate additional keys in databag
-        extra="ignore",
-        # Allow instantiating this class by field name (instead of forcing alias).
-        populate_by_name=True,
-        # Custom config key: whether to nest the whole datastructure (as json)
-        # under a field or spread it out at the toplevel.
-        _NEST_UNDER=None,
-    )  # type: ignore
-    """Pydantic config."""
+    class DatabagModel(pydantic.BaseModel):  # type: ignore
+        """Base databag model."""
 
-    @classmethod
-    def load(cls, databag: MutableMapping):
-        """Load this model from a Juju databag."""
-        nest_under = cls.model_config.get("_NEST_UNDER")
-        if nest_under:
-            return cls.model_validate(json.loads(databag[nest_under]))
+        class Config:
+            """Pydantic config."""
 
-        try:
-            data = {
-                k: json.loads(v)
-                for k, v in databag.items()
-                # Don't attempt to parse model-external values
-                if k in {(f.alias or n) for n, f in cls.model_fields.items()}
-            }
-        except json.JSONDecodeError as e:
-            msg = f"invalid databag contents: expecting json. {databag}"
-            logger.error(msg)
-            raise DataValidationError(msg) from e
+            # ignore any extra fields in the databag
+            extra = "ignore"
+            """Ignore any extra fields in the databag."""
+            allow_population_by_field_name = True
+            """Allow instantiating this class by field name (instead of forcing alias)."""
 
-        try:
-            return cls.model_validate_json(json.dumps(data))
-        except ValidationError as e:
-            msg = f"failed to validate databag: {databag}"
-            logger.debug(msg, exc_info=True)
-            raise DataValidationError(msg) from e
+        _NEST_UNDER = None
 
-    def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True):
-        """Write the contents of this model to Juju databag.
+        @classmethod
+        def load(cls, databag: MutableMapping):
+            """Load this model from a Juju databag."""
+            if cls._NEST_UNDER:
+                return cls.parse_obj(json.loads(databag[cls._NEST_UNDER]))
 
-        Args:
-            databag: The databag to write to.
-            clear: Whether to clear the databag before writing.
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {f.alias for f in cls.__fields__.values()}
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                logger.error(msg)
+                raise DataValidationError(msg) from e
 
-        Returns:
-            MutableMapping: The databag.
-        """
-        if clear and databag:
-            databag.clear()
+            try:
+                return cls.parse_raw(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                logger.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
 
-        if databag is None:
-            databag = {}
-        nest_under = self.model_config.get("_NEST_UNDER")
-        if nest_under:
-            databag[nest_under] = self.model_dump_json(
-                by_alias=True,
-                # skip keys whose values are default
-                exclude_defaults=True,
-            )
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True):
+            """Write the contents of this model to Juju databag.
+
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+
+            if self._NEST_UNDER:
+                databag[self._NEST_UNDER] = self.json(by_alias=True, exclude_defaults=False)
+                return databag
+
+            dct = json.loads(self.json(by_alias=True, exclude_defaults=False))
+            databag.update({k: json.dumps(v) for k, v in dct.items()})
+
             return databag
 
-        dct = self.model_dump(mode="json", by_alias=True, exclude_defaults=True)
-        databag.update({k: json.dumps(v) for k, v in dct.items()})
-        return databag
+else:
+
+    class DatabagModel(pydantic.BaseModel):
+        """Base databag model."""
+
+        model_config = pydantic.ConfigDict(
+            # tolerate additional keys in databag
+            extra="ignore",
+            # Allow instantiating this class by field name (instead of forcing alias).
+            populate_by_name=True,
+            # Custom config key: whether to nest the whole datastructure (as json)
+            # under a field or spread it out at the toplevel.
+            _NEST_UNDER=None,
+        )  # type: ignore
+        """Pydantic config."""
+
+        @classmethod
+        def load(cls, databag: MutableMapping):
+            """Load this model from a Juju databag."""
+            nest_under = cls.model_config.get("_NEST_UNDER")
+            if nest_under:
+                return cls.model_validate(json.loads(databag[nest_under]))
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {(f.alias or n) for n, f in cls.model_fields.items()}
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                logger.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.model_validate_json(json.dumps(data))
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                logger.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True):
+            """Write the contents of this model to Juju databag.
+
+            Args:
+                databag: The databag to write to.
+                clear: Whether to clear the databag before writing.
+
+            Returns:
+                MutableMapping: The databag.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+            nest_under = self.model_config.get("_NEST_UNDER")
+            if nest_under:
+                databag[nest_under] = self.model_dump_json(
+                    by_alias=True,
+                    # skip keys whose values are default
+                    exclude_defaults=True,
+                )
+                return databag
+
+            dct = self.model_dump(mode="json", by_alias=True, exclude_defaults=False)
+            databag.update({k: json.dumps(v) for k, v in dct.items()})
+            return databag
 
 
 class ProviderApplicationData(DatabagModel):
-    """App databag model."""
+    """Provider App databag model."""
 
-    certificates: Set[str] = Field(
-        description="The set of certificates that will be transferred to a requirer",
-        default=set(),
+    if int(pydantic.version.VERSION.split(".")[0]) < 2:
+        certificates: Set[str] = pydantic.Field(
+            description="The set of certificates that will be transferred to a requirer",
+            default_factory=set,
+        )
+    else:
+        certificates: Set[str] = pydantic.Field(
+            description="The set of certificates that will be transferred to a requirer",
+            default=set(),
+        )
+    version: int = pydantic.Field(
+        description="Version of the interface used in this databag",
+        default=1,
+    )
+
+
+class ProviderUnitDataV0(DatabagModel):
+    """Provider Unit databag v0 model."""
+
+    ca: str
+    certificate: str
+    chain: Optional[List[str]] = None
+    version: int = pydantic.Field(
+        description="Version of the interface used in this databag",
+        default=0,
+    )
+
+
+class RequirerApplicationData(DatabagModel):
+    """Requirer App databag model."""
+
+    version: int = pydantic.Field(
+        description="Version of the interface supported by this requirer",
+        default=1,
     )
 
 
@@ -212,7 +316,7 @@ class CertificateTransferProvides(Object):
     """Certificate Transfer provider class to be instantiated by charms sending certificates."""
 
     def __init__(self, charm: CharmBase, relationship_name: str):
-        super().__init__(charm, relationship_name)
+        super().__init__(charm, relationship_name + "_v1")
         self.charm = charm
         self.relationship_name = relationship_name
 
@@ -229,11 +333,11 @@ class CertificateTransferProvides(Object):
             None
         """
         if not self.charm.unit.is_leader():
-            logger.error("Only the leader unit can add certificates to this relation")
+            logger.warning("Only the leader unit can add certificates to this relation")
             return
-        relations = self._get_relevant_relations(relation_id)
+        relations = self._get_active_relations(relation_id)
         if not relations:
-            logger.error(
+            logger.warning(
                 "At least 1 matching relation ID not found with the relation name '%s'",
                 self.relationship_name,
             )
@@ -243,6 +347,31 @@ class CertificateTransferProvides(Object):
             existing_data = self._get_relation_data(relation)
             existing_data.update(certificates)
             self._set_relation_data(relation, existing_data)
+
+    def remove_all_certificates(self, relation_id: Optional[int] = None) -> None:
+        """Remove all certificates from relation data.
+
+        Removes all certificates from all relations if relation_id not given
+
+        Args:
+            relation_id (int): Relation ID
+
+        Returns:
+            None
+        """
+        if not self.charm.unit.is_leader():
+            logger.warning("Only the leader unit can add certificates to this relation")
+            return
+        relations = self._get_active_relations(relation_id)
+        if not relations:
+            logger.warning(
+                "At least 1 matching relation ID not found with the relation name '%s'",
+                self.relationship_name,
+            )
+            return
+
+        for relation in relations:
+            self._set_relation_data(relation, set())
 
     def remove_certificate(
         self,
@@ -261,11 +390,11 @@ class CertificateTransferProvides(Object):
             None
         """
         if not self.charm.unit.is_leader():
-            logger.error("Only the leader unit can add certificates to this relation")
+            logger.warning("Only the leader unit can add certificates to this relation")
             return
-        relations = self._get_relevant_relations(relation_id)
+        relations = self._get_active_relations(relation_id)
         if not relations:
-            logger.error(
+            logger.warning(
                 "At least 1 matching relation ID not found with the relation name '%s'",
                 self.relationship_name,
             )
@@ -276,31 +405,69 @@ class CertificateTransferProvides(Object):
             existing_data.discard(certificate)
             self._set_relation_data(relation, existing_data)
 
-    def _get_relevant_relations(self, relation_id: Optional[int] = None) -> List[Relation]:
-        """Get the relevant relation if relation_id is given, all relations otherwise."""
-        if (
-            relation_id is not None
-            and (
-                relation := self.model.get_relation(
-                    relation_name=self.relationship_name, relation_id=relation_id
-                )
+    def _get_active_relations(self, relation_id: Optional[int] = None) -> List[Relation]:
+        """Get the relation if relation_id is given and the relation is active, all active relations otherwise."""
+        if relation_id is not None:
+            relation = self.model.get_relation(
+                relation_name=self.relationship_name, relation_id=relation_id
             )
-            and relation.active
-        ):
-            return [relation]
+            if relation and relation.active:
+                return [relation]
+            return []
 
-        return list(self.model.relations[self.relationship_name])
+        return [
+            relation
+            for relation in self.model.relations[self.relationship_name]
+            if relation.active
+        ]
 
     def _set_relation_data(self, relation: Relation, data: Set[str]) -> None:
         """Set the given relation data."""
-        databag = relation.data[self.model.app]
-        ProviderApplicationData(certificates=data).dump(databag, False)
+        if relation.data.get(relation.app, {}).get("version", "0") == "1":
+            databag = relation.data[self.model.app]
+            ProviderApplicationData(certificates=data).dump(databag, True)
+        else:
+            if "version" in relation.data.get(relation.app, {}):
+                logger.warning(
+                    (
+                        "Requirer in relation %d is using version %s of the interface,",
+                        "defaulting to version 0.",
+                        "This is deprecated, please consider upgrading the requirer",
+                        "to version 1 of the library.",
+                    ),
+                    relation.id,
+                    relation.data[relation.app]["version"],
+                )
+            else:
+                logger.warning(
+                    (
+                        "Requirer in relation %d did not provide version field,",
+                        "defaulting to version 0.",
+                        "This is deprecated, please consider upgrading the requirer",
+                        "to version 1 of the library.",
+                    ),
+                    relation.id,
+                )
+
+            databag = relation.data[self.model.unit]
+            if data:
+                certificates = list(data)
+                ProviderUnitDataV0(
+                    ca=certificates[0], certificate=certificates[0], chain=certificates
+                ).dump(databag, True)
 
     def _get_relation_data(self, relation: Relation) -> Set[str]:
         """Get the given relation data."""
-        databag = relation.data[self.model.app]
         try:
-            return ProviderApplicationData().load(databag).certificates
+            if relation.data.get(relation.app, {}).get("version", "0") == "1":
+                databag = relation.data[self.model.app]
+                return ProviderApplicationData().load(databag).certificates
+            else:
+                databag = relation.data[self.model.unit]
+                certs = ProviderUnitDataV0.load(databag).chain
+                if certs is None:
+                    return set()
+                return set(certs)
         except DataValidationError as e:
             logger.error(
                 (
@@ -379,7 +546,7 @@ class CertificateTransferRequires(Object):
             charm: Charm object
             relationship_name: Juju relation name
         """
-        super().__init__(charm, relationship_name)
+        super().__init__(charm, relationship_name + "_v1")
         self.relationship_name = relationship_name
         self.charm = charm
         self.framework.observe(
@@ -387,6 +554,9 @@ class CertificateTransferRequires(Object):
         )
         self.framework.observe(
             charm.on[relationship_name].relation_broken, self._on_relation_broken
+        )
+        self.framework.observe(
+            charm.on[relationship_name].relation_created, self._on_relation_created
         )
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
@@ -415,6 +585,21 @@ class CertificateTransferRequires(Object):
         """
         self.on.certificates_removed.emit(relation_id=event.relation.id)
 
+    def _on_relation_created(self, event: RelationCreatedEvent) -> None:
+        """Handle relation created event.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        if not self.model.unit.is_leader():
+            logger.debug("Only leader unit sets the version number in the app databag")
+            return
+        databag = event.relation.data[self.model.app]
+        RequirerApplicationData().dump(databag, False)
+
     def get_all_certificates(self, relation_id: Optional[int] = None) -> Set[str]:
         """Get transferred certificates.
 
@@ -424,18 +609,34 @@ class CertificateTransferRequires(Object):
         Args:
             relation_id: The id of the relation to get the certificates from.
         """
-        relations = self._get_relevant_relations(relation_id)
+        relations = self._get_active_relations(relation_id)
         result = set()
         for relation in relations:
             data = self._get_relation_data(relation)
             result = result.union(data)
         return result
 
-    def _get_relation_data(self, relation: Relation) -> Set[str]:
-        """Get the given relation data."""
+    def is_ready(self, relation: Relation) -> bool:
+        """Check if the relation is ready by checking that it has valid relation data."""
         databag = relation.data[relation.app]
         try:
-            return ProviderApplicationData().load(databag).certificates
+            ProviderApplicationData().load(databag)
+            return True
+        except DataValidationError:
+            return False
+
+    def _get_relation_data(self, relation: Relation) -> Set[str]:
+        """Get the given relation data."""
+        try:
+            databag = relation.data[relation.app]
+            certificates = ProviderApplicationData().load(databag).certificates
+            if not certificates and relation.units:
+                databag = relation.data.get(relation.units.pop(), {})
+                certs = ProviderUnitDataV0.load(databag).chain
+                if certs is None:
+                    return set()
+                return set(certs)
+            return certificates
         except DataValidationError as e:
             logger.error(
                 (
@@ -448,11 +649,15 @@ class CertificateTransferRequires(Object):
             )
             return set()
 
-    def _get_relevant_relations(self, relation_id: Optional[int] = None) -> List[Relation]:
-        """Get the relevant relation if relation_id is given, all relations otherwise."""
+    def _get_active_relations(self, relation_id: Optional[int] = None) -> List[Relation]:
+        """Get the active relation if relation_id is given, all active relations otherwise."""
         if relation_id is not None:
             if relation := self.model.get_relation(
                 relation_name=self.relationship_name, relation_id=relation_id
             ):
                 return [relation]
-        return list(self.model.relations[self.relationship_name])
+        return [
+            relation
+            for relation in self.model.relations[self.relationship_name]
+            if relation.active
+        ]

--- a/src/charm.py
+++ b/src/charm.py
@@ -901,8 +901,8 @@ class JimmOperatorCharm(CharmBase):
         # doesn't support v0 relations. We append the _v1 suffix since this is what
         # the library does when creating the relation.
         # See https://github.com/canonical/certificate-transfer-interface/issues/171
-        cert_transfer_integrations = self.trusted_cert_transfer.charm.model.relations[
-            CERTIFICATE_TRANSFER_INTEGRATION_NAME + "_v1"
+        cert_transfer_integrations = self.model.relations[
+            CERTIFICATE_TRANSFER_INTEGRATION_NAME
         ]
 
         for integration in cert_transfer_integrations:

--- a/src/charm.py
+++ b/src/charm.py
@@ -896,9 +896,13 @@ class JimmOperatorCharm(CharmBase):
 
         ca_certs = self.trusted_cert_transfer.get_all_certificates()
 
-        # deal with v0 relations
+        # deal with v0 relations:
+        # Here we reach directly into the data-bag since the v1 cert-transfer library
+        # doesn't support v0 relations. We append the _v1 suffix since this is what
+        # the library does when creating the relation.
+        # See https://github.com/canonical/certificate-transfer-interface/issues/171
         cert_transfer_integrations = self.trusted_cert_transfer.charm.model.relations[
-            CERTIFICATE_TRANSFER_INTEGRATION_NAME
+            CERTIFICATE_TRANSFER_INTEGRATION_NAME + "_v1"
         ]
 
         for integration in cert_transfer_integrations:

--- a/src/charm.py
+++ b/src/charm.py
@@ -901,11 +901,23 @@ class JimmOperatorCharm(CharmBase):
         # doesn't support v0 relations. We append the _v1 suffix since this is what
         # the library does when creating the relation.
         # See https://github.com/canonical/certificate-transfer-interface/issues/171
-        cert_transfer_integrations = self.model.relations[
+        cert_transfer_integrations = self.trusted_cert_transfer.charm.model.relations[
             CERTIFICATE_TRANSFER_INTEGRATION_NAME
         ]
 
+        all_relations = self.model.relations
+        logger.warning(f"all relations {all_relations.keys()}")
+        for name, relations in all_relations.items():
+            logger.warning(f"relation {name}")
+            for relation in relations:
+                logger.warning(f"relation id {relation.id} with app data = {relation.data.get(relation.app, {})}")
+                for unit in relation.units:
+                    logger.warning(f"unit {unit.name} data = {relation.data.get(unit, {})}")
+
         for integration in cert_transfer_integrations:
+            if "ca" in integration.data[integration.app]:
+                ca = {integration.data[integration.app]["ca"]}
+                ca_certs.update(ca)
             ca = {integration.data[unit]["ca"] for unit in integration.units if "ca" in integration.data.get(unit, {})}
             ca_certs.update(ca)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -889,10 +889,15 @@ class JimmOperatorCharm(CharmBase):
         Returns:
             bool: A boolean to indicate whether the workload service should be restarted.
         """
-        if not self.model.get_relation(relation_name=self.trusted_cert_transfer.relationship_name):
-            return False
-
         logger.info("Validating trusted ca certificates.")
+
+        logger.warning("Dumping all relations to help debug certificate issues.")
+        for name, relations in self.model.relations.items():
+            logger.warning(f"relation {name}")
+            for relation in relations:
+                logger.warning(f"relation id {relation.id} with app data = {relation.data.get(relation.app, {})}")
+                for unit in relation.units:
+                    logger.warning(f"unit {unit.name} data = {relation.data.get(unit, {})}")
 
         ca_certs = self.trusted_cert_transfer.get_all_certificates()
 
@@ -905,9 +910,8 @@ class JimmOperatorCharm(CharmBase):
             CERTIFICATE_TRANSFER_INTEGRATION_NAME
         ]
 
-        all_relations = self.model.relations
-        logger.warning(f"all relations {all_relations.keys()}")
-        for name, relations in all_relations.items():
+        logger.warning("Dumping all relations to help debug certificate issues.")
+        for name, relations in self.model.relations.items():
             logger.warning(f"relation {name}")
             for relation in relations:
                 logger.warning(f"relation id {relation.id} with app data = {relation.data.get(relation.app, {})}")


### PR DESCRIPTION
## Description
This PR attempts to update the cert-transfer charm library to the latest version while still accomodating relations with v0 providers.

The latest versions of the v1 library changed the relation name to append `_v1` so the workaround for handling relations with v0 providers requires a tweak.