### PR TITLE
test: re-enable iam platform test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,7 +67,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           channel: 1.28-strict/stable
-          juju-channel: 3.4/stable
+          juju-channel: 3.6/stable
           provider: microk8s
           microk8s-group: snap_microk8s
           microk8s-addons: "ingress hostpath-storage dns registry metallb:10.64.140.43/30"

--- a/tests/integration/identity-bundle.yaml
+++ b/tests/integration/identity-bundle.yaml
@@ -1,0 +1,91 @@
+bundle: kubernetes
+name: identity-platform
+description: |
+  The Canonical Identity Platform is a composable identity broker and identity provider based on open source products.
+docs: https://discourse.charmhub.io/t/canonical-identity-platform/11825
+website: https://github.com/canonical/iam-bundle
+issues: https://github.com/canonical/iam-bundle/issues
+applications:
+  hydra:
+    charm: hydra
+    revision: 339
+    resources:
+      oci-image: ghcr.io/canonical/hydra:2.3.0-canonical
+    channel: latest/edge
+    scale: 1
+    series: jammy
+    trust: true
+  kratos:
+    charm: kratos
+    revision: 500
+    resources:
+      oci-image: ghcr.io/canonical/kratos:1.3.1
+    channel: latest/edge
+    scale: 1
+    series: jammy
+    trust: true
+  kratos-external-idp-integrator:
+    charm: kratos-external-idp-integrator
+    channel: latest/edge
+    revision: 245
+    scale: 1
+    series: jammy
+  identity-platform-login-ui-operator:
+    charm: identity-platform-login-ui-operator
+    revision: 146
+    resources:
+      oci-image: ghcr.io/canonical/identity-platform-login-ui:v0.21.2
+    channel: latest/edge
+    scale: 1
+    series: jammy
+    trust: true
+  postgresql-k8s:
+    charm: postgresql-k8s
+    channel: 14/stable
+    resources:
+      postgresql-image: ghcr.io/canonical/charmed-postgresql@sha256:e2283194f7f8d9997fb06f0fd1ab0ec3938ce73ac001133bd8fd393ebe83acc7
+    series: jammy
+    scale: 1
+    trust: true
+    options:
+      plugin_pg_trgm_enable: true
+      plugin_btree_gin_enable: true
+  self-signed-certificates:
+    charm: self-signed-certificates
+    revision: 155
+    channel: latest/stable
+    scale: 1
+  traefik-admin:
+    charm: traefik-k8s
+    channel: latest/stable
+    revision: 176
+    resources:
+      traefik-image: docker.io/ubuntu/traefik:2-22.04
+    series: focal
+    scale: 1
+    trust: true
+  traefik-public:
+    charm: traefik-k8s
+    channel: latest/stable
+    revision: 176
+    resources:
+      traefik-image: docker.io/ubuntu/traefik:2-22.04
+    series: focal
+    scale: 1
+    trust: true
+relations:
+  - [hydra:pg-database, postgresql-k8s:database]
+  - [kratos:pg-database, postgresql-k8s:database]
+  - [kratos:hydra-endpoint-info, hydra:hydra-endpoint-info]
+  - [kratos-external-idp-integrator:kratos-external-idp, kratos:kratos-external-idp]
+  - [hydra:admin-ingress, traefik-admin:ingress]
+  - [hydra:public-ingress, traefik-public:ingress]
+  - [kratos:admin-ingress, traefik-admin:ingress]
+  - [kratos:public-ingress, traefik-public:ingress]
+  - [identity-platform-login-ui-operator:ingress, traefik-public:ingress]
+  - [identity-platform-login-ui-operator:hydra-endpoint-info, hydra:hydra-endpoint-info]
+  - [identity-platform-login-ui-operator:ui-endpoint-info, hydra:ui-endpoint-info]
+  - [identity-platform-login-ui-operator:ui-endpoint-info, kratos:ui-endpoint-info]
+  - [identity-platform-login-ui-operator:kratos-info, kratos:kratos-info]
+  - [traefik-admin:certificates, self-signed-certificates:certificates]
+  - [traefik-public:certificates, self-signed-certificates:certificates]

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -42,7 +42,6 @@ async def test_build_and_deploy(
     await deploy_jimm(ops_test, charm, hydra_app_name, self_signed_certificates_app_name, ext_idp_service)
 
 
-@pytest.mark.skip("Failing due to a new breaking resource in the login UI charm")
 async def test_jimm_oauth_browser_login(
     ops_test: OpsTest,
     charm,

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -43,7 +43,8 @@ async def deploy_jimm(
     # Deploy the identity bundle first because it checks everything is in an active state and if we deploy JIMM apps
     # at the same time, then that check will fail.
     logger.info("deploying identity bundle")
-    await deploy_identity_bundle(ops_test=ops_test, bundle_channel="latest/edge", ext_idp_service=ext_idp_service)
+    bundle_path = Path(__file__).parent / "identity-bundle.yaml"
+    await deploy_identity_bundle(ops_test=ops_test, bundle_url=str(bundle_path), ext_idp_service=ext_idp_service)
 
     # Deploy the charm and wait for active/idle status
     logger.info("deploying charms")


### PR DESCRIPTION
## Description

This PR adds a workaround to re-enable testing our charm with the identity platform. Previously due to a breaking change in one of the resources in one of the identity platform's charms, we needed to skip our integration test. This change adds a vendored version of the identity platform bundle that pins the correct revision of the identity platform charms + resources.

## Engineering checklist

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests
