### PR TITLE
fix: use correct dns for oauth client config

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -859,7 +859,7 @@ class JimmOperatorCharm(CharmBase):
 
     @property
     def _oauth_client_config(self) -> ClientConfig:
-        dns = self.config.get("dns-name")
+        dns = self._get_dns_name(None)
         if dns is None or dns == "":
             dns = "http://localhost"
         dns = ensureFQDN(str(dns))

--- a/src/state.py
+++ b/src/state.py
@@ -24,7 +24,8 @@ def requires_state(func):
         if self._state.is_ready():
             return func(self, event)
         else:
-            event.defer()
+            if event is not None:
+                event.defer()
             return
 
     return wrapper


### PR DESCRIPTION
## Description

This PR fixes #90. The oauth client config we pass to the oauth library sets the redirect URL (i.e. `jimm.com/auth/callback`) by fetching the base URL from `self.config.get("dns-name")`. This config value is okay to use if set by the user, but when the charm is related to an ingress like Traefik, the ingress provides the full base URL which usually has a path prefix like `jimm.com/<model>-<app>/`. Using the helper function `_get_dns_name()` will correctly handle this for us.

The one thing to note is that `_get_dns_name()` expects an event parameter as the function is wrapped in a `requires_state()` decorator which will defer the event if state is not available yet. We cannot modify `_oauth_client_config()` to accept an `event` from its caller, because it's used as a property and passed to the oauth library on each `update_workload()`. All that to say, we just need to avoid calling `defer()` on a `None` object.

## Engineering checklist

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests

