### PR TITLE
chore: update JIMM TF module

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -2,35 +2,35 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/random" {
-  version     = "3.7.1"
-  constraints = ">= 3.6.0"
+  version     = "3.7.2"
+  constraints = "~> 3.0"
   hashes = [
-    "h1:/qtweZW2sk0kBNiQM02RvBXmlVdI9oYqRMCyBZ8XA98=",
-    "zh:3193b89b43bf5805493e290374cdda5132578de6535f8009547c8b5d7a351585",
-    "zh:3218320de4be943e5812ed3de995946056db86eb8d03aa3f074e0c7316599bef",
-    "zh:419861805a37fa443e7d63b69fb3279926ccf98a79d256c422d5d82f0f387d1d",
-    "zh:4df9bd9d839b8fc11a3b8098a604b9b46e2235eb65ef15f4432bde0e175f9ca6",
-    "zh:5814be3f9c9cc39d2955d6f083bae793050d75c572e70ca11ccceb5517ced6b1",
-    "zh:63c6548a06de1231c8ee5570e42ca09c4b3db336578ded39b938f2156f06dd2e",
-    "zh:697e434c6bdee0502cc3deb098263b8dcd63948e8a96d61722811628dce2eba1",
+    "h1:356j/3XnXEKr9nyicLUufzoF4Yr6hRy481KIxRVpK0c=",
+    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
+    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
+    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
+    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
+    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
+    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:a0b8e44927e6327852bbfdc9d408d802569367f1e22a95bcdd7181b1c3b07601",
-    "zh:b7d3af018683ef22794eea9c218bc72d7c35a2b3ede9233b69653b3c782ee436",
-    "zh:d63b911d618a6fe446c65bfc21e793a7663e934b2fef833d42d3ccd38dd8d68d",
-    "zh:fa985cd0b11e6d651f47cff3055f0a9fd085ec190b6dbe99bf5448174434cdea",
+    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
+    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
+    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
+    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
+    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
   ]
 }
 
 provider "registry.terraform.io/juju/juju" {
-  version     = "0.18.0"
-  constraints = ">= 0.18.0"
+  version     = "1.0.0"
+  constraints = "~> 1.0"
   hashes = [
-    "h1:IFhO4oQZeBwEqEwbJdK8lK2RlRKWsEPyUYm55rrHu54=",
-    "zh:0c3abdcbf35df30e4ba422b8470dadfa97a41fc2b3a99c46f87950eb65d026ce",
-    "zh:0c53600cea3bd782e41681354227c8f2539d62c699b81a7e1b40547e67ead339",
-    "zh:40156afa8456a5a9df216ae7d6119e33b79a52b85feed1c2257fb6bcc41fd17f",
+    "h1:UAE5KGIz0GcecsFUu2vv0hrzlH/93XEeP+pWqXRr7o4=",
+    "zh:2badfce96acbcfe026e76a2b67f3670d95e324e62b179428a0b398f5b4a8e69c",
+    "zh:69509cb8593d69ec0820876c0de46bb9748b586d10f74390911854c5deeadd03",
     "zh:753ad16d007180a77a147bd377de2fb334f409123f6fee36d4c50c7fe8b76a29",
-    "zh:e42eae13fdb8684f43b66c3a1219d8b3daad0aba62a52f50304fed00d296140a",
-    "zh:fb04fffff06bbc3096c9d21e0c87326ff8611d3006f6acda1b0821b4938de965",
+    "zh:d6e899b7e818281afe83ab347743c08f8d62dd5aa1296902dc407b51b21790ef",
+    "zh:fdff39ba011a94feb3e8db144d0877557df360fca68e763b374216132474bcef",
+    "zh:ffee88ff525e9b959f1306e1026c03f018e96640585dd63af1dce3cee383b4c4",
   ]
 }

--- a/terraform/cos_integration.tf
+++ b/terraform/cos_integration.tf
@@ -1,19 +1,6 @@
-# Add these to your data resources section
-data "juju_offer" "logging_consumer" {
-  url = var.logging_consumer_offer_url
-}
-
-data "juju_offer" "metrics_endpoint" {
-  url = var.metrics_endpoint_offer_url
-}
-
-data "juju_offer" "grafana_dashboard_consumer" {
-  url = var.grafana_dashboard_consumer_offer_url
-}
-
 # Add these integration resources
 resource "juju_integration" "grafana_metrics_endpoint" {
-  model = juju_model.jimm.name
+  count = var.metrics_endpoint_offer_url != null ? 1 : 0
 
   application {
     name     = juju_application.grafana_agent.name
@@ -21,25 +8,27 @@ resource "juju_integration" "grafana_metrics_endpoint" {
   }
 
   application {
-    offer_url = data.juju_offer.metrics_endpoint.url
+    offer_url = var.metrics_endpoint_offer_url
   }
+  model_uuid = var.model_uuid
 }
 
 resource "juju_integration" "grafana_logging_consumer" {
-  model = juju_model.jimm.name
+  count = var.logging_consumer_offer_url != null ? 1 : 0
 
   application {
-    name     = juju_application.grafana_agent
+    name     = juju_application.grafana_agent.name
     endpoint = "logging-consumer"
   }
 
   application {
-    offer_url = data.juju_offer.logging_consumer.url
+    offer_url = var.logging_consumer_offer_url
   }
+  model_uuid = var.model_uuid
 }
 
 resource "juju_integration" "grafana_dashboard_consumer" {
-  model = juju_model.jimm.name
+  count = var.grafana_dashboard_consumer_offer_url != null ? 1 : 0
 
   application {
     name     = juju_application.grafana_agent.name
@@ -47,12 +36,13 @@ resource "juju_integration" "grafana_dashboard_consumer" {
   }
 
   application {
-    offer_url = data.juju_offer.grafana_dashboard_consumer.url
+    offer_url = var.grafana_dashboard_consumer_offer_url
   }
+  model_uuid = var.model_uuid
 }
 
 resource "juju_integration" "jimm_grafana_agent_logging" {
-  model = juju_model.jimm.name
+  count = var.logging_consumer_offer_url != null ? 1 : 0
 
   application {
     name     = juju_application.jimm.name
@@ -62,10 +52,11 @@ resource "juju_integration" "jimm_grafana_agent_logging" {
   application {
     name = juju_application.grafana_agent.name
   }
+  model_uuid = var.model_uuid
 }
 
 resource "juju_integration" "jimm_grafana_agent_metric_endpoints" {
-  model = juju_model.jimm.name
+  count = var.metrics_endpoint_offer_url != null ? 1 : 0
 
   application {
     name     = juju_application.jimm.name
@@ -75,11 +66,12 @@ resource "juju_integration" "jimm_grafana_agent_metric_endpoints" {
   application {
     name = juju_application.grafana_agent.name
   }
+  model_uuid = var.model_uuid
 }
 
 
 resource "juju_integration" "jimm_grafana_agent_dashboard" {
-  model = juju_model.jimm.name
+  count = var.grafana_dashboard_consumer_offer_url != null ? 1 : 0
 
   application {
     name     = juju_application.jimm.name
@@ -89,4 +81,5 @@ resource "juju_integration" "jimm_grafana_agent_dashboard" {
   application {
     name = juju_application.grafana_agent.name
   }
+  model_uuid = var.model_uuid
 }

--- a/terraform/integrations.tf
+++ b/terraform/integrations.tf
@@ -1,29 +1,12 @@
 ### Integrations ###
-# The reason why we have this data is to verify the offer exists for the offer variable
-# set in the variables.
 
-data "juju_offer" "database" {
-  url = var.postgresql_offer_url
-}
-
-data "juju_offer" "ingress" {
-  url = var.ingress_offer_url
-}
-
-data "juju_offer" "openfga" {
-  url = var.openfga_offer_url
-}
-
-data "juju_offer" "vault" {
-  url = var.vault_offer_url
-}
-
-data "juju_offer" "oauth" {
-  url = var.oauth_offer_url
-}
+# TODO: Once https://github.com/juju/terraform-provider-juju/pull/989 is merged
+# and released, we can uncomment the lines below to allow a module user to
+# provide either an offer URL or an application name for the integration target. 
 
 resource "juju_integration" "jimm_openfga" {
-  model = juju_model.jimm.name
+  count      = var.openfga.offer_url != null || var.openfga.application_name != null ? 1 : 0
+  model_uuid = var.model_uuid
 
   application {
     name     = juju_application.jimm.name
@@ -31,12 +14,14 @@ resource "juju_integration" "jimm_openfga" {
   }
 
   application {
-    offer_url = data.juju_offer.openfga.url
+    # offer_url = var.openfga.offer_url != null ? var.openfga.offer_url : null
+    name = var.openfga.application_name != null ? var.openfga.application_name : null
   }
 }
 
 resource "juju_integration" "jimm_vault" {
-  model = juju_model.jimm.name
+  count      = var.vault.offer_url != null || var.vault.application_name != null ? 1 : 0
+  model_uuid = var.model_uuid
 
   application {
     name     = juju_application.jimm.name
@@ -44,12 +29,14 @@ resource "juju_integration" "jimm_vault" {
   }
 
   application {
-    offer_url = data.juju_offer.vault.url
+    # offer_url = var.vault.offer_url != null ? var.vault.offer_url : null
+    name = var.vault.application_name != null ? var.vault.application_name : null
   }
 }
 
 resource "juju_integration" "jimm_postgresql" {
-  model = juju_model.jimm.name
+  count      = var.postgresql.offer_url != null || var.postgresql.application_name != null ? 1 : 0
+  model_uuid = var.model_uuid
 
   application {
     name     = juju_application.jimm.name
@@ -57,24 +44,28 @@ resource "juju_integration" "jimm_postgresql" {
   }
 
   application {
-    offer_url = data.juju_offer.database.url
+    offer_url = var.postgresql.offer_url != null ? var.postgresql.offer_url : null
+    # name      = var.postgresql.application_name != null ? var.postgresql.application_name : null
   }
 }
 
 resource "juju_integration" "jimm_oauth" {
-  model = juju_model.jimm.name
+  count      = var.oauth.offer_url != null || var.oauth.application_name != null ? 1 : 0
+  model_uuid = var.model_uuid
 
   application {
     name = juju_application.jimm.name
   }
 
   application {
-    offer_url = data.juju_offer.oauth.url
+    # offer_url = var.oauth.offer_url != null ? var.oauth.offer_url : null
+    name = var.oauth.application_name != null ? var.oauth.application_name : null
   }
 }
 
 resource "juju_integration" "jimm_ingress" {
-  model = juju_model.jimm.name
+  count      = var.ingress.offer_url != null || var.ingress.application_name != null ? 1 : 0
+  model_uuid = var.model_uuid
 
   application {
     name     = juju_application.jimm.name
@@ -82,7 +73,8 @@ resource "juju_integration" "jimm_ingress" {
   }
 
   application {
-    offer_url = data.juju_offer.ingress.url
+    # offer_url = var.ingress.offer_url != null ? var.ingress.offer_url : null
+    name = var.ingress.application_name != null ? var.ingress.application_name : null
   }
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,11 +1,6 @@
 ### Applications ###
-resource "juju_model" "jimm" {
-  name = var.model
-}
-
 resource "juju_application" "jimm" {
   name  = var.name
-  model = juju_model.jimm.name
   trust = var.trust
   units = var.units
 
@@ -26,6 +21,7 @@ resource "juju_application" "jimm" {
     private-key             = sensitive(var.jimm_config.private_key)
   }
 
+  model_uuid = var.model_uuid
 }
 
 ### Misc ###
@@ -36,8 +32,7 @@ resource "random_uuid" "jimm-uuid" {
 
 
 resource "juju_application" "grafana_agent" {
-  name  = "grafana-agent"
-  model = juju_model.jimm.name
+  name = "grafana-agent"
 
   charm {
     name     = var.grafana_agent_charm.name
@@ -45,4 +40,5 @@ resource "juju_application" "grafana_agent" {
     base     = var.grafana_agent_charm.base
     revision = var.grafana_agent_charm.revision
   }
+  model_uuid = var.model_uuid
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,4 +1,4 @@
-variable "model" {
+variable "model_uuid" {
   type    = string
   default = "jimm"
 }
@@ -77,44 +77,65 @@ variable "grafana_agent_charm" {
   }
 }
 
-variable "oauth_offer_url" {
-  description = "OAuth Offer URL"
-  type        = string
-  default     = ""
+variable "oauth" {
+  description = "OAuth integration configuration. Provide either offer_url or application_name."
+  type = object({
+    offer_url        = optional(string)
+    application_name = optional(string)
+  })
+  default = {}
 }
 
-variable "postgresql_offer_url" {
-  description = "PostgreSQL Offer URL"
-  type        = string
+variable "postgresql" {
+  description = "PostgreSQL integration configuration. Provide either offer_url or application_name."
+  type = object({
+    offer_url        = optional(string)
+    application_name = optional(string)
+  })
+  default = {}
 }
 
-variable "openfga_offer_url" {
-  description = "OpenFGA Offer URL"
-  type        = string
+variable "openfga" {
+  description = "OpenFGA integration configuration. Provide either offer_url or application_name."
+  type = object({
+    offer_url        = optional(string)
+    application_name = optional(string)
+  })
+  default = {}
 }
 
-variable "vault_offer_url" {
-  description = "Vault Offer URL"
-  type        = string
-  default     = ""
+variable "vault" {
+  description = "Vault integration configuration. Provide either offer_url or application_name."
+  type = object({
+    offer_url        = optional(string)
+    application_name = optional(string)
+  })
+  default = {}
 }
 
-variable "ingress_offer_url" {
-  description = "Ingress Offer URL"
-  type        = string
+variable "ingress" {
+  description = "Ingress integration configuration. Provide either offer_url or application_name."
+  type = object({
+    offer_url        = optional(string)
+    application_name = optional(string)
+  })
+  default = {}
 }
 
 variable "metrics_endpoint_offer_url" {
   description = "Grafana Metrics Endpoint Offer URL"
   type        = string
+  default     = null
 }
 
 variable "logging_consumer_offer_url" {
   description = "Grafana Agent Logging Offer URL"
   type        = string
+  default     = null
 }
 
 variable "grafana_dashboard_consumer_offer_url" {
   description = "Grafana Agent Dashboard Offer URL"
   type        = string
+  default     = null
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.18.0"
+      version = "~> 1.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.6.0"
+      version = "~> 3.0"
     }
   }
 }


### PR DESCRIPTION
## Description

This PR updates the JIMM Terraform module which deploys JIMM and grafana-agent and creates integrations between  JIMM and other components like Postgres and OpenFGA.

The changes I've made to the module include:
- Updates to support TF v1.0.0.
- Changes integrations to handle cross-model relations or same-model relations (this is a WIP and requires https://github.com/juju/terraform-provider-juju/pull/989 to be released).
- Made relation creation optional depending on the relation details passed.
- Removed data sources that validate offer URLs making this a requirement of the caller.

Partially addresses [JUJU-7852](https://warthogs.atlassian.net/browse/JUJU-7852)


[JUJU-7852]: https://warthogs.atlassian.net/browse/JUJU-7852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ