### PR TITLE
fix: properly handle urls with path prefix

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -123,10 +123,7 @@ class JimmOperatorCharm(CharmBase):
         super().__init__(*args)
 
         self._state = State(self.app, lambda: self.model.get_relation("peer"))
-        self.oauth = OAuthRequirer(self, self._oauth_client_config, relation_name=OAUTH)
 
-        self.framework.observe(self.oauth.on.oauth_info_changed, self._on_oauth_info_changed)
-        self.framework.observe(self.oauth.on.oauth_info_removed, self._on_oauth_info_changed)
         self.framework.observe(self.on.peer_relation_changed, self._on_peer_relation_changed)
         self.framework.observe(self.on.jimm_pebble_ready, self._on_jimm_pebble_ready)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
@@ -193,6 +190,12 @@ class JimmOperatorCharm(CharmBase):
         require_nginx_route(
             charm=self, service_hostname=self.config.get("dns-name", ""), service_name=self.app.name, service_port=8080
         )
+
+        # OAuth relation
+        # Set this up after ingress as the ingress object is used to construct redirect URLs.
+        self.oauth = OAuthRequirer(self, self._oauth_client_config, relation_name=OAUTH)
+        self.framework.observe(self.oauth.on.oauth_info_changed, self._on_oauth_info_changed)
+        self.framework.observe(self.oauth.on.oauth_info_removed, self._on_oauth_info_changed)
 
         # Database relation
         self.database = DatabaseRequires(

--- a/src/charm.py
+++ b/src/charm.py
@@ -669,12 +669,7 @@ class JimmOperatorCharm(CharmBase):
 
     @requires_state
     def _get_dns_name(self, event) -> str:
-        default_dns_name = ""
-        dns_name = self.config.get("dns-name", default_dns_name)
-        if self._state.dns_name:
-            dns_name = self._state.dns_name
-
-        return dns_name
+        return self.ingress.url or str(self.config.get("dns-name", ""))
 
     def _get_host_key(self) -> str:
         """
@@ -763,19 +758,19 @@ class JimmOperatorCharm(CharmBase):
 
     @requires_state_setter
     def _on_ingress_ready(self, event: IngressPerAppReadyEvent) -> None:
-        self._state.dns_name = event.url
+        logger.info(f"Ingress for HTTP/S at {event.url}")
 
         self._update_workload(event)
 
     def _on_ingress_ssh_ready(self, event: IngressPerUnitReadyForUnitEvent):
-        logger.info(f"Ingress for ssh at {event.url}")
+        logger.info(f"Ingress for SSH at {event.url}")
 
     def _on_ingress_ssh_revoked(self, _):
-        logger.info("I have lost my ingress URL!")
+        logger.info("This app no longer has SSH ingress")
 
     @requires_state_setter
     def _on_ingress_revoked(self, event: IngressPerAppRevokedEvent) -> None:
-        del self._state.dns_name
+        logger.info("This app no longer has HTTP/S ingress")
 
         self._update_workload(event)
 
@@ -863,8 +858,9 @@ class JimmOperatorCharm(CharmBase):
         if dns is None or dns == "":
             dns = "http://localhost"
         dns = ensureFQDN(str(dns))
+        dns = ensureAbsoluteURL(dns)
         return ClientConfig(
-            redirect_uri=urljoin(dns, "/auth/callback"),
+            redirect_uri=urljoin(dns, "auth/callback"),
             scope=OAUTH_SCOPES,
             grant_types=OAUTH_GRANT_TYPES,
             token_endpoint_auth_method="client_secret_post",
@@ -964,6 +960,16 @@ def ensureFQDN(dns: str) -> str:  # noqa: N802
     """Ensures a domain name has an https:// prefix."""
     if not dns.startswith("http"):
         dns = "https://" + dns
+    return dns
+
+
+def ensureAbsoluteURL(dns: str) -> str:  # noqa: N802
+    """
+    Ensures a domain name has a trailing slash.
+    This prevents methods like urljoin from stripping path components.
+    """
+    if not dns.endswith("/"):
+        dns = dns + "/"
     return dns
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -441,6 +441,10 @@ class TestCharm(TestCase):
         oauth_client = self.harness.charm._oauth_client_config
         self.assertEqual(oauth_client.redirect_uri, "https://jimm.com/auth/callback")
 
+        self.harness.update_config({"dns-name": "jimm.com/some/path"})
+        oauth_client = self.harness.charm._oauth_client_config
+        self.assertEqual(oauth_client.redirect_uri, "https://jimm.com/some/path/auth/callback")
+
     def test_app_enters_block_states_if_oauth_relation_removed(self):
         self.harness.update_config(MINIMAL_CONFIG)
         self.harness.remove_relation(self.oauth_rel_id)
@@ -490,24 +494,11 @@ class TestCharm(TestCase):
         self.assertEqual(plan.to_dict(), get_expected_plan(expected_env))
 
     def test_dashboard_relation_joined(self):
-        harness = Harness(JimmOperatorCharm)
-        self.addCleanup(harness.cleanup)
+        self.start_minimal_jimm()
 
-        id = harness.add_relation("peer", "juju-jimm-k8s")
-        harness.add_relation_unit(id, "juju-jimm-k8s/1")
-        harness.begin()
-        harness.set_leader(True)
-        harness.update_config(
-            {
-                "dns-name": "jimm.localhost",
-                "controller-admins": "user1 user2 group1",
-                "uuid": "caaa4ba4-e2b5-40dd-9bf3-2bd26d6e17aa",
-            }
-        )
-
-        id = harness.add_relation("dashboard", "juju-dashboard")
-        harness.add_relation_unit(id, "juju-dashboard/0")
-        data = harness.get_relation_data(id, "juju-jimm-k8s")
+        id = self.harness.add_relation("dashboard", "juju-dashboard")
+        self.harness.add_relation_unit(id, "juju-dashboard/0")
+        data = self.harness.get_relation_data(id, "juju-jimm-k8s")
 
         self.assertTrue(data)
         self.assertEqual(


### PR DESCRIPTION
## Description

This PR is a follow-up to https://github.com/canonical/jimm-k8s-operator/pull/91 which fetched the redirect_url that we pass to Hydra from the correct place (the relation with the ingress charm, falling back to a manual value).

There was still an error when the URL provided had a path segment, e.g. `jimm.com/some/path`, we were calling `urljoin(dns, "/auth/callback")` which was replacing the entire path segment with `/auth/callback` instead of appending it. This PR fixes this issue and as a modernization avoids the use of `self._state.dns_name` and simply fetches the value from the relation.

## Engineering checklist
- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests