### PR TITLE
chore: update terraform plan to resolve integration todo

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -22,15 +22,15 @@ provider "registry.terraform.io/hashicorp/random" {
 }
 
 provider "registry.terraform.io/juju/juju" {
-  version     = "1.0.0"
+  version     = "1.1.1"
   constraints = "~> 1.0"
   hashes = [
-    "h1:UAE5KGIz0GcecsFUu2vv0hrzlH/93XEeP+pWqXRr7o4=",
-    "zh:2badfce96acbcfe026e76a2b67f3670d95e324e62b179428a0b398f5b4a8e69c",
-    "zh:69509cb8593d69ec0820876c0de46bb9748b586d10f74390911854c5deeadd03",
+    "h1:r5C+wa4JHIDLX4uZ3XW+J6arhF4UKD5NNX5GIiazWKc=",
+    "zh:3d07c0ff92cc7148b2afa34fd3e820486165b9a17b9220e499ebe142128fee36",
+    "zh:55a1a865d2449f9a9dca59d83415e8317f6015f282d3da079d777d225bfad813",
+    "zh:57df44a860b7f2ddb6b67b3e5782a4bc05780ab26003d97f6e263525a8f1af3f",
     "zh:753ad16d007180a77a147bd377de2fb334f409123f6fee36d4c50c7fe8b76a29",
-    "zh:d6e899b7e818281afe83ab347743c08f8d62dd5aa1296902dc407b51b21790ef",
-    "zh:fdff39ba011a94feb3e8db144d0877557df360fca68e763b374216132474bcef",
-    "zh:ffee88ff525e9b959f1306e1026c03f018e96640585dd63af1dce3cee383b4c4",
+    "zh:83c5c076c9164e00380a06f228e32f53efa29ed71322bdd9e1becb92a8a7a843",
+    "zh:f61fc46552ba066344402470f45a5ad956eca49becc3b549272bee37313ec334",
   ]
 }

--- a/terraform/cos_integration.tf
+++ b/terraform/cos_integration.tf
@@ -3,7 +3,7 @@ resource "juju_integration" "grafana_metrics_endpoint" {
   count = var.metrics_endpoint_offer_url != null ? 1 : 0
 
   application {
-    name     = juju_application.grafana_agent.name
+    name     = juju_application.grafana_agent[0].name
     endpoint = "metrics-endpoint"
   }
 
@@ -17,7 +17,7 @@ resource "juju_integration" "grafana_logging_consumer" {
   count = var.logging_consumer_offer_url != null ? 1 : 0
 
   application {
-    name     = juju_application.grafana_agent.name
+    name     = juju_application.grafana_agent[0].name
     endpoint = "logging-consumer"
   }
 
@@ -31,7 +31,7 @@ resource "juju_integration" "grafana_dashboard_consumer" {
   count = var.grafana_dashboard_consumer_offer_url != null ? 1 : 0
 
   application {
-    name     = juju_application.grafana_agent.name
+    name     = juju_application.grafana_agent[0].name
     endpoint = "grafana-dashboards-consumer"
   }
 
@@ -50,7 +50,7 @@ resource "juju_integration" "jimm_grafana_agent_logging" {
   }
 
   application {
-    name = juju_application.grafana_agent.name
+    name = juju_application.grafana_agent[0].name
   }
   model_uuid = var.model_uuid
 }
@@ -64,7 +64,7 @@ resource "juju_integration" "jimm_grafana_agent_metric_endpoints" {
   }
 
   application {
-    name = juju_application.grafana_agent.name
+    name = juju_application.grafana_agent[0].name
   }
   model_uuid = var.model_uuid
 }
@@ -79,7 +79,7 @@ resource "juju_integration" "jimm_grafana_agent_dashboard" {
   }
 
   application {
-    name = juju_application.grafana_agent.name
+    name = juju_application.grafana_agent[0].name
   }
   model_uuid = var.model_uuid
 }

--- a/terraform/integrations.tf
+++ b/terraform/integrations.tf
@@ -11,7 +11,7 @@ resource "juju_integration" "jimm_openfga" {
 
   application {
     offer_url = var.openfga.offer_url != null ? var.openfga.offer_url : null
-    name = var.openfga.application_name != null ? var.openfga.application_name : null
+    name      = var.openfga.application_name != null ? var.openfga.application_name : null
   }
 }
 
@@ -26,7 +26,7 @@ resource "juju_integration" "jimm_vault" {
 
   application {
     offer_url = var.vault.offer_url != null ? var.vault.offer_url : null
-    name = var.vault.application_name != null ? var.vault.application_name : null
+    name      = var.vault.application_name != null ? var.vault.application_name : null
   }
 }
 
@@ -55,7 +55,7 @@ resource "juju_integration" "jimm_oauth" {
 
   application {
     offer_url = var.oauth.offer_url != null ? var.oauth.offer_url : null
-    name = var.oauth.application_name != null ? var.oauth.application_name : null
+    name      = var.oauth.application_name != null ? var.oauth.application_name : null
   }
 }
 
@@ -70,7 +70,7 @@ resource "juju_integration" "jimm_ingress" {
 
   application {
     offer_url = var.ingress.offer_url != null ? var.ingress.offer_url : null
-    name = var.ingress.application_name != null ? var.ingress.application_name : null
+    name      = var.ingress.application_name != null ? var.ingress.application_name : null
   }
 }
 

--- a/terraform/integrations.tf
+++ b/terraform/integrations.tf
@@ -1,9 +1,5 @@
 ### Integrations ###
 
-# TODO: Once https://github.com/juju/terraform-provider-juju/pull/989 is merged
-# and released, we can uncomment the lines below to allow a module user to
-# provide either an offer URL or an application name for the integration target. 
-
 resource "juju_integration" "jimm_openfga" {
   count      = var.openfga.offer_url != null || var.openfga.application_name != null ? 1 : 0
   model_uuid = var.model_uuid
@@ -14,7 +10,7 @@ resource "juju_integration" "jimm_openfga" {
   }
 
   application {
-    # offer_url = var.openfga.offer_url != null ? var.openfga.offer_url : null
+    offer_url = var.openfga.offer_url != null ? var.openfga.offer_url : null
     name = var.openfga.application_name != null ? var.openfga.application_name : null
   }
 }
@@ -29,7 +25,7 @@ resource "juju_integration" "jimm_vault" {
   }
 
   application {
-    # offer_url = var.vault.offer_url != null ? var.vault.offer_url : null
+    offer_url = var.vault.offer_url != null ? var.vault.offer_url : null
     name = var.vault.application_name != null ? var.vault.application_name : null
   }
 }
@@ -45,7 +41,7 @@ resource "juju_integration" "jimm_postgresql" {
 
   application {
     offer_url = var.postgresql.offer_url != null ? var.postgresql.offer_url : null
-    # name      = var.postgresql.application_name != null ? var.postgresql.application_name : null
+    name      = var.postgresql.application_name != null ? var.postgresql.application_name : null
   }
 }
 
@@ -58,7 +54,7 @@ resource "juju_integration" "jimm_oauth" {
   }
 
   application {
-    # offer_url = var.oauth.offer_url != null ? var.oauth.offer_url : null
+    offer_url = var.oauth.offer_url != null ? var.oauth.offer_url : null
     name = var.oauth.application_name != null ? var.oauth.application_name : null
   }
 }
@@ -73,7 +69,7 @@ resource "juju_integration" "jimm_ingress" {
   }
 
   application {
-    # offer_url = var.ingress.offer_url != null ? var.ingress.offer_url : null
+    offer_url = var.ingress.offer_url != null ? var.ingress.offer_url : null
     name = var.ingress.application_name != null ? var.ingress.application_name : null
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -32,6 +32,8 @@ resource "random_uuid" "jimm-uuid" {
 
 
 resource "juju_application" "grafana_agent" {
+  count = var.deploy_grafana_agent ? 1 : 0
+
   name = "grafana-agent"
 
   charm {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -61,6 +61,12 @@ variable "units" {
   default     = 3 #
 }
 
+variable "deploy_grafana_agent" {
+  description = "Whether to deploy the Grafana Agent application alongside JIMM."
+  type        = bool
+  default     = false
+}
+
 variable "grafana_agent_charm" {
   description = "The grafana agent application charm operator information."
   type = object({


### PR DESCRIPTION
## Description

This PR resolves a TODO in the Terraform module for deploying JIMM. Since v1.1.0 of the Terraform provider the module can now more easily accept cross-model or same-model relations.

The lock file has been updated to pin to v1.1.1 of the Juju TF Provider.