### PR TITLE
fix: avoid double schema on login_token_refresh_url

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -368,7 +368,13 @@ class JimmOperatorCharm(CharmBase):
             logger.warning("dns name not set")
             return
 
-        login_token_refresh_url = "https://" + dns_name + "/.well-known/jwks.json"
+        parsed_dns_name = urlparse(dns_name)
+        if parsed_dns_name.scheme:
+            dns_without_scheme = f"{parsed_dns_name.netloc}{parsed_dns_name.path}"
+        else:
+            dns_without_scheme = dns_name
+        dns_without_scheme = dns_without_scheme.lstrip("/").rstrip("/")
+        login_token_refresh_url = f"https://{dns_without_scheme}/.well-known/jwks.json"
 
         oauth_provider_info = self.oauth.get_provider_info()
         if not oauth_provider_info:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -319,6 +319,32 @@ class TestCharm(TestCase):
         plan = self.harness.get_container_pebble_plan("jimm")
         self.assertEqual(plan.to_dict(), get_expected_plan(EXPECTED_VAULT_ENV))
 
+    def test_bootstrap_login_token_refresh_url_strips_scheme(self):
+        self.harness.enable_hooks()
+        self.use_fake_session_secret()
+        self.use_fake_host_key()
+        self.use_fake_setup_fga_model()
+        self.create_auth_model_info()
+        self.add_openfga_relation()
+        self.add_vault_relation()
+        self.add_postgres_relation()
+
+        config_with_scheme = {**MINIMAL_CONFIG, "dns-name": "https://jimm.localhost"}
+        self.harness.update_config(config_with_scheme)
+
+        container = self.harness.model.unit.get_container("jimm")
+        self.harness.charm.on.jimm_pebble_ready.emit(container)
+
+        plan = self.harness.get_container_pebble_plan("jimm")
+        plan_dict = plan.to_dict()
+        services = plan_dict.get("services", {})
+        service = services.get(JIMM_SERVICE_NAME, {})
+        env = service.get("environment", {})
+        self.assertEqual(
+            env.get("JIMM_BOOTSTRAP_LOGIN_TOKEN_REFRESH_URL"),
+            "https://jimm.localhost/.well-known/jwks.json",
+        )
+
     def test_ready_without_plan(self):
         self.harness.enable_hooks()
         self.harness.charm._ready()


### PR DESCRIPTION
## Description

Ensures that the `login_token_refresh_url` variable set on JIMM's `JIMM_BOOTSTRAP_LOGIN_TOKEN_REFRESH_URL` variable doesn't have the scheme repeated, currently you can run into a situation where the url is `https://https://`.
 
## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests
