### PR TITLE
feat(segregrate): segregate internal and public paths in JIMM

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -51,6 +51,9 @@ requires:
   ingress:
     interface: ingress
     limit: 1
+  internal-ingress:
+    interface: ingress
+    limit: 1
   ingress-ssh:
     interface: ingress_per_unit
     limit: 1
@@ -93,4 +96,4 @@ resources:
   jimm-image:
     type: oci-image
     description: OCI image for JIMM.
-    upstream-source: ghcr.io/canonical/jimm:v3.3.17
+    upstream-source: ghcr.io/canonical/jimm:v3.3.18

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -96,4 +96,4 @@ resources:
   jimm-image:
     type: oci-image
     description: OCI image for JIMM.
-    upstream-source: ghcr.io/canonical/jimm:v3.3.18
+    upstream-source: ghcr.io/canonical/jimm:v3.3.21

--- a/src/charm.py
+++ b/src/charm.py
@@ -158,12 +158,18 @@ class JimmOperatorCharm(CharmBase):
             self._on_certificate_revoked,
         )
 
-        # Traefik ingress relation
+        # Traefik ingress relations
         self.ingress = IngressPerAppRequirer(
             self,
             relation_name="ingress",
             strip_prefix=True,
             port=8080,
+        )
+        self.internal_ingress = IngressPerAppRequirer(
+            self,
+            relation_name="internal-ingress",
+            strip_prefix=True,
+            port=9090,
         )
 
         # if the unit is the leader we set the port. We set the port just for the leader,
@@ -183,6 +189,12 @@ class JimmOperatorCharm(CharmBase):
         self.framework.observe(self.ingress.on.ready, self._on_ingress_ready)
         self.framework.observe(
             self.ingress.on.revoked,
+            self._on_ingress_revoked,
+        )
+
+        self.framework.observe(self.internal_ingress.on.ready, self._on_ingress_ready)
+        self.framework.observe(
+            self.internal_ingress.on.revoked,
             self._on_ingress_revoked,
         )
 
@@ -421,6 +433,7 @@ class JimmOperatorCharm(CharmBase):
             "JIMM_DSN": self._make_database_dsn(),
             "JIMM_JWT_EXPIRY": self.config.get("jwt-expiry"),
             "JIMM_LISTEN_ADDR": ":8080",
+            "JIMM_INTERNAL_LISTEN_ADDR": ":9090",
             "JIMM_LOG_LEVEL": self.config.get("log-level", ""),
             "JIMM_MACAROON_EXPIRY_DURATION": self.config.get("macaroon-expiry-duration", "24h"),
             "JIMM_OAUTH_CLIENT_ID": oauth_provider_info.client_id,

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -84,6 +84,11 @@ async def deploy_jimm(
                 application_name="traefik",
                 channel="latest/stable",
             ),
+            ops_test.model.deploy(
+                "traefik-k8s",
+                application_name="traefik-internal",
+                channel="latest/stable",
+            ),
         )
 
     logger.info("waiting for postgresql")
@@ -116,6 +121,5 @@ async def deploy_jimm(
     await ops_test.model.integrate(f"{APP_NAME}:ingress-ssh", "traefik")
 
     await ops_test.model.wait_for_idle(timeout=2000)
-    jimm_debug_info = requests.get(f"{JIMM_ADDRESS}/debug/info")
-    assert jimm_debug_info.status_code == 200
-    logger.info("jimm info = %s", jimm_debug_info.json())
+    macaroon_publickey = requests.get(f"{JIMM_ADDRESS}/macaroons/publickey")
+    assert macaroon_publickey.status_code == 200

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -84,11 +84,6 @@ async def deploy_jimm(
                 application_name="traefik",
                 channel="latest/stable",
             ),
-            ops_test.model.deploy(
-                "traefik-k8s",
-                application_name="traefik-internal",
-                channel="latest/stable",
-            ),
         )
 
     logger.info("waiting for postgresql")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -66,6 +66,7 @@ BASE_ENV = {
     "JIMM_DASHBOARD_LOCATION": "https://jaas.ai/models",
     "JIMM_DNS_NAME": "jimm.localhost",
     "JIMM_DSN": "postgresql://postgres-user:postgres-pass@local-1.localhost/jimm",
+    "JIMM_INTERNAL_LISTEN_ADDR": ":9090",
     "JIMM_IS_LEADER": "True",
     "JIMM_JWT_EXPIRY": "5m",
     "JIMM_LISTEN_ADDR": ":8080",


### PR DESCRIPTION


## Description

Now we expose internal paths on another port so we need another traefik ingress for it.

We currently don't test the traefik ingress, so i didn't add any test for it.
But i did the manual qa.

# QA

`charmcraft pack`
`tox -e integration -- --keep-models --localCharm`

`juju relate traefik:ingress juju-jimm-k8s:ingress`
`juju relate traefik-internal:ingress juju-jimm-k8s:internal-ingress`

`juju run  traefik/0 show-proxied-endpoints`

For the public routes you should still be able to query from the traefik endpoint `/macaroons/publickey`

`juju run  traefik-internal/0 show-proxied-endpoints`

For the internal routes you can call `/debug/status`
