### PR TITLE
chore: reduce renovate PR frequency

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
       ":semanticCommitScope(deps)",
       "helpers:pinGitHubActionDigests"
     ],
+    "schedule": ["* * 1 * *"], 
     "automergeType": "pr",
     "rebaseWhen": "behind-base-branch",
     "packageRules": [
@@ -18,15 +19,12 @@
         "groupName": "github actions",
         "matchManagers": ["github-actions"],
         "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
-        "automerge": true,
-        "schedule": ["at any time"],
         "additionalBranchPrefix": "auto-"
       },
       {
         "groupName": "operator pip deps (minor changes)",
         "matchManagers": ["pip_requirements"],
         "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-        "schedule": ["at any time"],
         "prPriority": 5,
         "additionalBranchPrefix": "auto-"
       },
@@ -34,23 +32,18 @@
         "groupName": "operator pip deps (major changes)",
         "matchManagers": ["pip_requirements"],
         "matchUpdateTypes": ["major"],
-        "schedule": ["at any time"],
         "prPriority": 5
       },
       {
         "groupName": "testing deps",
         "matchFiles": ["tox.ini"],
         "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
-        "automerge": true,
-        "schedule": ["on monday"],
         "additionalBranchPrefix": "auto-"
       },
       {
         "groupName": "renovate packages",
         "matchSourceUrlPrefixes": ["https://github.com/renovatebot/"],
         "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
-        "automerge": true,
-        "schedule": ["at any time"],
         "additionalBranchPrefix": "auto-"
       }
     ]


### PR DESCRIPTION
## Description

This change aims to reduce the frequency of renovate PRs/emails received whenever we land changes in this repo. We reduce the frequency of renovate PRs to once a month.

Docs on the format of the "schedule" key are [here](https://docs.renovatebot.com/key-concepts/scheduling/). It mentions that the human-readable form is deprecated and will be dropped in the future in favour of cron syntax. Unfortunately I can't put in a comment in the JSON file to reflect what the cron represents.

I've also removed the `automerge` keys. Although set to `true`, they weren't doing since we hadn't setup auto-merge on the repo.
