### PR TITLE
feat: ensure jwks secret is created on install and upgrade hooks

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -344,10 +344,12 @@ class JimmOperatorCharm(CharmBase):
         )
         self.ensure_session_secret_key()
         self.ensure_hostkey_secret_key()
+        self.ensure_jwks_secret_key()
 
     def _on_upgrade(self, event: UpgradeCharmEvent) -> None:
         self.ensure_session_secret_key()
         self.ensure_hostkey_secret_key()
+        self.ensure_jwks_secret_key()
 
     def _on_secret_changed(self, event: SecretChangedEvent) -> None:
         # Update the workload if ssh-host-key-secret-id is set in the config and the secret-changed event is fired.


### PR DESCRIPTION
## Description

After upgrading the JIMM charm in our test environment to revision 108 which implements JWKS creation/rotation in the charm, the charm's status was blocked with a message of "Waiting for JWKS secret" for a few minutes until eventually resolving to an active state. The `ensure_jwks_secret_key()` method was only being called in the status update hook (which triggers every 5 minutes).

To improve the upgrade experience, we should call `self.ensure_jwks_secret_key()` on the install and upgrade hooks, much in the same way we do for `self.ensure_session_secret_key()` and `self.ensure_hostkey_secret_key()`. This way things will resolve more quickly.