### PR TITLE
ci: add missing permissions to release workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,6 +18,9 @@ jobs:
     name: Release charm
     needs:
       - charm-tests
+    permissions:
+      contents: write # Needed to tag the release
+      packages: read # Needed to log into ghcr.io
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
## Description
Add missing token permissions to the release workflow. 

According to https://discourse.canonical.com/t/upcoming-change-to-github-actions-settings/7286 which affects workflows in the Canonical org,

> The [default workflow privileges](https://docs.github.com/en/enterprise-cloud@latest/admin/enforcing-policies/enforcing-policies-for-your-enterprise/enforcing-policies-for-github-actions-in-your-enterprise#workflow-permissions) will be changed from “read and write” to “read”.

This change was made on May 20 and our last fully working release was May 19. A release [made today](https://github.com/canonical/jimm-k8s-operator/actions/runs/27211841320/job/80351812966) was able to release to Charmhub but failed near the end with the error "Error: Resource not accessible by integration" when trying to tag the repo with the new release - which is a [known error](https://stackoverflow.com/questions/70435286/resource-not-accessible-by-integration-on-github-post-repos-owner-repo-ac) for missing Github permissions.