### PR TITLE
test: update integration test charms

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,19 +73,5 @@ Integration tests require the following setup:
 5. A Juju controller on microk8s `juju bootstrap microk8s`
 6. `kubectl` must be installed - `sudo snap install kubectl`
 7. Your kubectl must be configured to talk to microk8s - `microk8s config > ~/.kube/config`
-8. Setup the ability for Microk8s to pull from a private ghcr (Github Container Registry):
-   1. Obtain a Github PAT token that has at least `read:packages` access and can access `github.com/canonical/jimm`.
-   2. Run the following commands (adding values for the username/password placeholders):
-
-          read -r -d '' REGISTRY_CONFIG << EOL || true
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."ghcr.io".auth]
-              username = "<your-username-here>"
-              password = "<your-PAT-token-here>"
-          EOL
-                    
-          echo "$REGISTRY_CONFIG" | sudo tee -a /var/snap/microk8s/current/args/containerd-template.toml
-
-          sudo snap restart microk8s.daemon-containerd
-
-9.  Create the `venv` and install `tox` as described above.
-10. Run the test (optionally keep the model for debugging) - `tox -e integration -- --keep-models`
+8.  Create the `venv` and install `tox` as described above.
+9.  Run the test (optionally keep the model for debugging) - `tox -e integration -- --keep-models`

--- a/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
@@ -657,82 +657,25 @@ class CertificateTransferRequires(Object):
 
     def is_ready(self, relation: Relation) -> bool:
         """Check if the relation is ready by checking that it has valid relation data."""
+        databag = relation.data[relation.app]
         try:
-            self._get_relation_data(relation)
+            ProviderApplicationData().load(databag)
             return True
         except DataValidationError:
             return False
-
-    def _get_v0_relation_data(self, relation: Relation) -> Set[str]:
-        """Load certificates from a v0 provider databag.
-
-        Older providers may write the certificate set into either the application
-        databag or a unit databag, so check both without mutating relation.units.
-        """
-        databags = [relation.data[relation.app]]
-        databags.extend(relation.data.get(unit, {}) for unit in relation.units)
-
-        last_error: DataValidationError | None = None
-        for databag in databags:
-            if not databag:
-                continue
-            legacy_certs = self._get_legacy_relation_data(databag)
-            if legacy_certs is not None:
-                return legacy_certs
-            try:
-                certs = ProviderUnitDataV0.load(databag).chain
-                if certs is None:
-                    return set()
-                return set(certs)
-            except DataValidationError as exc:
-                last_error = exc
-
-        if last_error is not None:
-            raise last_error
-        return set()
-
-    @staticmethod
-    def _get_legacy_relation_data(databag: MutableMapping) -> Optional[Set[str]]:
-        """Parse legacy raw-string CA transfer databags.
-
-        Some older providers send the CA PEM as a plain string in `ca` and an optional
-        JSON-encoded `chain` list without the v0 `certificate` field or JSON encoding
-        for every value. Accept that shape for backwards compatibility.
-        """
-        ca = databag.get("ca")
-        chain = databag.get("chain")
-        certificate = databag.get("certificate")
-        if ca is None and chain is None and certificate is None:
-            return None
-
-        certificates: List[str] = []
-        if isinstance(chain, str) and chain:
-            try:
-                parsed_chain = json.loads(chain)
-                if isinstance(parsed_chain, list):
-                    certificates.extend(cert for cert in parsed_chain if isinstance(cert, str) and cert)
-            except json.JSONDecodeError:
-                certificates.append(chain)
-
-        if isinstance(certificate, str) and certificate:
-            certificates.append(certificate)
-        if isinstance(ca, str) and ca:
-            certificates.insert(0, ca)
-
-        return set(certificates)
 
     def _get_relation_data(self, relation: Relation) -> Set[str]:
         """Get the given relation data."""
         try:
             databag = relation.data[relation.app]
-            try:
-                certificates = ProviderApplicationData().load(databag).certificates
-            except DataValidationError:
-                return self._get_v0_relation_data(relation)
-
-            if certificates:
-                return certificates
-            return self._get_v0_relation_data(relation)
+            certificates = ProviderApplicationData().load(databag).certificates
+            if not certificates and relation.units:
+                databag = relation.data.get(relation.units.pop(), {})
+                certs = ProviderUnitDataV0.load(databag).chain
+                if certs is None:
+                    return set()
+                return set(certs)
+            return certificates
         except DataValidationError as e:
             logger.error(
                 (

--- a/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
@@ -4,7 +4,15 @@
 """Library for the certificate_transfer relation.
 
 This library contains the Requires and Provides classes for handling the
-certificate-transfer interface.
+certificate-transfer interface. It supports both v0 and v1 of the interface.
+
+For requirers, they will set version 1 in their application databag as a hint to
+the provider. They will read the databag from the provider first as v1, and fallback
+to v0 if the format does not match.
+
+For providers, they will check the version in the requirer's application databag,
+and send v1 if that version is set to 1, otherwise it will default to 0 for backwards
+compatibility.
 
 ## Getting Started
 From a charm directory, fetch the library using `charmcraft`:
@@ -92,8 +100,9 @@ juju integrate <certificate_transfer provider charm> <certificate_transfer requi
 
 import json
 import logging
-from typing import List, MutableMapping, Optional, Set
+from typing import Dict, List, MutableMapping, Optional, Set
 
+import pydantic
 from ops import (
     CharmEvents,
     EventBase,
@@ -102,10 +111,10 @@ from ops import (
     Relation,
     RelationBrokenEvent,
     RelationChangedEvent,
+    RelationCreatedEvent,
 )
 from ops.charm import CharmBase
 from ops.framework import Object
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 # The unique Charmhub library identifier, never change it
 LIBID = "3785165b24a743f2b0c60de52db25c8b"
@@ -115,11 +124,13 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 15
 
 logger = logging.getLogger(__name__)
 
 PYDEPS = ["pydantic"]
+
+IS_PYDANTIC_V1 = int(pydantic.version.VERSION.split(".")[0]) < 2
 
 
 class TLSCertificatesError(Exception):
@@ -130,10 +141,26 @@ class DataValidationError(TLSCertificatesError):
     """Raised when data validation fails."""
 
 
-class DatabagModel(BaseModel):
-    """Base databag model."""
+class DatabagModel(pydantic.BaseModel):
+    """Base databag model.
 
-    model_config = ConfigDict(
+    Supports both pydantic v1 and v2.
+    """
+
+    if IS_PYDANTIC_V1:
+
+        class Config:
+            """Pydantic config."""
+
+            # ignore any extra fields in the databag
+            extra = "ignore"
+            """Ignore any extra fields in the databag."""
+            allow_population_by_field_name = True
+            """Allow instantiating this class by field name (instead of forcing alias)."""
+
+        _NEST_UNDER = None
+
+    model_config = pydantic.ConfigDict(
         # tolerate additional keys in databag
         extra="ignore",
         # Allow instantiating this class by field name (instead of forcing alias).
@@ -147,6 +174,8 @@ class DatabagModel(BaseModel):
     @classmethod
     def load(cls, databag: MutableMapping):
         """Load this model from a Juju databag."""
+        if IS_PYDANTIC_V1:
+            return cls._load_v1(databag)
         nest_under = cls.model_config.get("_NEST_UNDER")
         if nest_under:
             return cls.model_validate(json.loads(databag[nest_under]))
@@ -165,7 +194,32 @@ class DatabagModel(BaseModel):
 
         try:
             return cls.model_validate_json(json.dumps(data))
-        except ValidationError as e:
+        except pydantic.ValidationError as e:
+            msg = f"failed to validate databag: {databag}"
+            logger.debug(msg, exc_info=True)
+            raise DataValidationError(msg) from e
+
+    @classmethod
+    def _load_v1(cls, databag: MutableMapping):
+        """Load implementation for pydantic v1."""
+        if cls._NEST_UNDER:
+            return cls.parse_obj(json.loads(databag[cls._NEST_UNDER]))
+
+        try:
+            data = {
+                k: json.loads(v)
+                for k, v in databag.items()
+                # Don't attempt to parse model-external values
+                if k in {f.alias for f in cls.__fields__.values()}
+            }
+        except json.JSONDecodeError as e:
+            msg = f"invalid databag contents: expecting json. {databag}"
+            logger.error(msg)
+            raise DataValidationError(msg) from e
+
+        try:
+            return cls.parse_raw(json.dumps(data))  # type: ignore
+        except pydantic.ValidationError as e:
             msg = f"failed to validate databag: {databag}"
             logger.debug(msg, exc_info=True)
             raise DataValidationError(msg) from e
@@ -180,6 +234,8 @@ class DatabagModel(BaseModel):
         Returns:
             MutableMapping: The databag.
         """
+        if IS_PYDANTIC_V1:
+            return self._dump_v1(databag, clear)
         if clear and databag:
             databag.clear()
 
@@ -194,17 +250,65 @@ class DatabagModel(BaseModel):
             )
             return databag
 
-        dct = self.model_dump(mode="json", by_alias=True, exclude_defaults=True)
+        dct = self.model_dump(mode="json", by_alias=True, exclude_defaults=False)
         databag.update({k: json.dumps(v) for k, v in dct.items()})
+        return databag
+
+    def _dump_v1(self, databag: Optional[MutableMapping] = None, clear: bool = True):
+        """Dump implementation for pydantic v1."""
+        if clear and databag:
+            databag.clear()
+
+        if databag is None:
+            databag = {}
+
+        if self._NEST_UNDER:
+            databag[self._NEST_UNDER] = self.json(by_alias=True, exclude_defaults=False)
+            return databag
+
+        dct = json.loads(self.json(by_alias=True, exclude_defaults=False))
+        databag.update({k: json.dumps(v) for k, v in dct.items()})
+
         return databag
 
 
 class ProviderApplicationData(DatabagModel):
-    """App databag model."""
+    """Provider App databag model."""
 
-    certificates: Set[str] = Field(
-        description="The set of certificates that will be transferred to a requirer",
-        default=set(),
+    if int(pydantic.version.VERSION.split(".")[0]) < 2:
+        certificates: Set[str] = pydantic.Field(
+            description="The set of certificates that will be transferred to a requirer",
+            default_factory=set,
+        )
+    else:
+        certificates: Set[str] = pydantic.Field(
+            description="The set of certificates that will be transferred to a requirer",
+            default=set(),
+        )
+    version: int = pydantic.Field(
+        description="Version of the interface used in this databag",
+        default=1,
+    )
+
+
+class ProviderUnitDataV0(DatabagModel):
+    """Provider Unit databag v0 model."""
+
+    ca: str
+    certificate: str
+    chain: Optional[List[str]] = None
+    version: int = pydantic.Field(
+        description="Version of the interface used in this databag",
+        default=0,
+    )
+
+
+class RequirerApplicationData(DatabagModel):
+    """Requirer App databag model."""
+
+    version: int = pydantic.Field(
+        description="Version of the interface supported by this requirer",
+        default=1,
     )
 
 
@@ -212,7 +316,7 @@ class CertificateTransferProvides(Object):
     """Certificate Transfer provider class to be instantiated by charms sending certificates."""
 
     def __init__(self, charm: CharmBase, relationship_name: str):
-        super().__init__(charm, relationship_name)
+        super().__init__(charm, relationship_name + "_v1")
         self.charm = charm
         self.relationship_name = relationship_name
 
@@ -229,20 +333,57 @@ class CertificateTransferProvides(Object):
             None
         """
         if not self.charm.unit.is_leader():
-            logger.error("Only the leader unit can add certificates to this relation")
+            logger.warning("Only the leader unit can add certificates to this relation")
             return
-        relations = self._get_relevant_relations(relation_id)
+        relations = self._get_active_relations(relation_id)
         if not relations:
-            logger.error(
-                "At least 1 matching relation ID not found with the relation name '%s'",
-                self.relationship_name,
-            )
+            if relation_id is not None:
+                logger.debug(
+                    "At least 1 matching relation ID not found with the relation name '%s'",
+                    self.relationship_name,
+                )
+            else:
+                logger.debug(
+                    "No active relations found with the relation name '%s'",
+                    self.relationship_name,
+                )
             return
 
         for relation in relations:
             existing_data = self._get_relation_data(relation)
             existing_data.update(certificates)
             self._set_relation_data(relation, existing_data)
+
+    def remove_all_certificates(self, relation_id: Optional[int] = None) -> None:
+        """Remove all certificates from relation data.
+
+        Removes all certificates from all relations if relation_id not given
+
+        Args:
+            relation_id (int): Relation ID
+
+        Returns:
+            None
+        """
+        if not self.charm.unit.is_leader():
+            logger.warning("Only the leader unit can add certificates to this relation")
+            return
+        relations = self._get_active_relations(relation_id)
+        if not relations:
+            if relation_id is not None:
+                logger.debug(
+                    "At least 1 matching relation ID not found with the relation name '%s'",
+                    self.relationship_name,
+                )
+            else:
+                logger.debug(
+                    "No active relations found with the relation name '%s'",
+                    self.relationship_name,
+                )
+            return
+
+        for relation in relations:
+            self._set_relation_data(relation, set())
 
     def remove_certificate(
         self,
@@ -261,14 +402,20 @@ class CertificateTransferProvides(Object):
             None
         """
         if not self.charm.unit.is_leader():
-            logger.error("Only the leader unit can add certificates to this relation")
+            logger.warning("Only the leader unit can add certificates to this relation")
             return
-        relations = self._get_relevant_relations(relation_id)
+        relations = self._get_active_relations(relation_id)
         if not relations:
-            logger.error(
-                "At least 1 matching relation ID not found with the relation name '%s'",
-                self.relationship_name,
-            )
+            if relation_id is not None:
+                logger.debug(
+                    "At least 1 matching relation ID not found with the relation name '%s'",
+                    self.relationship_name,
+                )
+            else:
+                logger.debug(
+                    "No active relations found with the relation name '%s'",
+                    self.relationship_name,
+                )
             return
 
         for relation in relations:
@@ -276,31 +423,69 @@ class CertificateTransferProvides(Object):
             existing_data.discard(certificate)
             self._set_relation_data(relation, existing_data)
 
-    def _get_relevant_relations(self, relation_id: Optional[int] = None) -> List[Relation]:
-        """Get the relevant relation if relation_id is given, all relations otherwise."""
-        if (
-            relation_id is not None
-            and (
-                relation := self.model.get_relation(
-                    relation_name=self.relationship_name, relation_id=relation_id
-                )
+    def _get_active_relations(self, relation_id: Optional[int] = None) -> List[Relation]:
+        """Get the relation if relation_id is given and the relation is active, all active relations otherwise."""
+        if relation_id is not None:
+            relation = self.model.get_relation(
+                relation_name=self.relationship_name, relation_id=relation_id
             )
-            and relation.active
-        ):
-            return [relation]
+            if relation and relation.active:
+                return [relation]
+            return []
 
-        return list(self.model.relations[self.relationship_name])
+        return [
+            relation
+            for relation in self.model.relations[self.relationship_name]
+            if relation.active
+        ]
 
     def _set_relation_data(self, relation: Relation, data: Set[str]) -> None:
         """Set the given relation data."""
-        databag = relation.data[self.model.app]
-        ProviderApplicationData(certificates=data).dump(databag, False)
+        if relation.data.get(relation.app, {}).get("version", "0") == "1":
+            databag = relation.data[self.model.app]
+            ProviderApplicationData(certificates=data).dump(databag, True)
+        else:
+            if "version" in relation.data.get(relation.app, {}):
+                logger.warning(
+                    (
+                        "Requirer in relation %d is using version %s of the interface,",
+                        "defaulting to version 0.",
+                        "This is deprecated, please consider upgrading the requirer",
+                        "to version 1 of the library.",
+                    ),
+                    relation.id,
+                    relation.data[relation.app]["version"],
+                )
+            else:
+                logger.warning(
+                    (
+                        "Requirer in relation %d did not provide version field,",
+                        "defaulting to version 0.",
+                        "This is deprecated, please consider upgrading the requirer",
+                        "to version 1 of the library.",
+                    ),
+                    relation.id,
+                )
+
+            databag = relation.data[self.model.unit]
+            if data:
+                certificates = list(data)
+                ProviderUnitDataV0(
+                    ca=certificates[0], certificate=certificates[0], chain=certificates
+                ).dump(databag, True)
 
     def _get_relation_data(self, relation: Relation) -> Set[str]:
         """Get the given relation data."""
-        databag = relation.data[self.model.app]
         try:
-            return ProviderApplicationData().load(databag).certificates
+            if relation.data.get(relation.app, {}).get("version", "0") == "1":
+                databag = relation.data[self.model.app]
+                return ProviderApplicationData().load(databag).certificates
+            else:
+                databag = relation.data[self.model.unit]
+                certs = ProviderUnitDataV0.load(databag).chain
+                if certs is None:
+                    return set()
+                return set(certs)
         except DataValidationError as e:
             logger.error(
                 (
@@ -379,7 +564,7 @@ class CertificateTransferRequires(Object):
             charm: Charm object
             relationship_name: Juju relation name
         """
-        super().__init__(charm, relationship_name)
+        super().__init__(charm, relationship_name + "_v1")
         self.relationship_name = relationship_name
         self.charm = charm
         self.framework.observe(
@@ -387,6 +572,9 @@ class CertificateTransferRequires(Object):
         )
         self.framework.observe(
             charm.on[relationship_name].relation_broken, self._on_relation_broken
+        )
+        self.framework.observe(
+            charm.on[relationship_name].relation_created, self._on_relation_created
         )
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
@@ -415,6 +603,21 @@ class CertificateTransferRequires(Object):
         """
         self.on.certificates_removed.emit(relation_id=event.relation.id)
 
+    def _on_relation_created(self, event: RelationCreatedEvent) -> None:
+        """Handle relation created event.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        if not self.model.unit.is_leader():
+            logger.debug("Only leader unit sets the version number in the app databag")
+            return
+        databag = event.relation.data[self.model.app]
+        RequirerApplicationData().dump(databag, False)
+
     def get_all_certificates(self, relation_id: Optional[int] = None) -> Set[str]:
         """Get transferred certificates.
 
@@ -424,18 +627,112 @@ class CertificateTransferRequires(Object):
         Args:
             relation_id: The id of the relation to get the certificates from.
         """
-        relations = self._get_relevant_relations(relation_id)
+        relations = self._get_active_relations(relation_id)
         result = set()
         for relation in relations:
             data = self._get_relation_data(relation)
             result = result.union(data)
         return result
 
+    def get_all_certificates_by_relation(
+        self, relation_id: Optional[int] = None
+    ) -> Dict[int, List[str]]:
+        """Get a deterministic list of certificates grouped by relation.
+
+        - Grouped by relation_id.
+        - The list order is sorted lexicographically by PEM content.
+
+        Args:
+            relation_id: If provided, only certificates for this relation are returned.
+
+        Returns:
+            Dict where keys are relation IDs and values are ordered lists of PEMs.
+        """
+        relations = self._get_active_relations(relation_id)
+        result: Dict[int, List[str]] = {}
+        for relation in relations:
+            certificates = sorted(self._get_relation_data(relation))
+            result[relation.id] = certificates
+        return result
+
+    def is_ready(self, relation: Relation) -> bool:
+        """Check if the relation is ready by checking that it has valid relation data."""
+        try:
+            self._get_relation_data(relation)
+            return True
+        except DataValidationError:
+            return False
+
+    def _get_v0_relation_data(self, relation: Relation) -> Set[str]:
+        """Load certificates from a v0 provider databag.
+
+        Older providers may write the certificate set into either the application
+        databag or a unit databag, so check both without mutating relation.units.
+        """
+        databags = [relation.data[relation.app]]
+        databags.extend(relation.data.get(unit, {}) for unit in relation.units)
+
+        last_error: DataValidationError | None = None
+        for databag in databags:
+            if not databag:
+                continue
+            legacy_certs = self._get_legacy_relation_data(databag)
+            if legacy_certs is not None:
+                return legacy_certs
+            try:
+                certs = ProviderUnitDataV0.load(databag).chain
+                if certs is None:
+                    return set()
+                return set(certs)
+            except DataValidationError as exc:
+                last_error = exc
+
+        if last_error is not None:
+            raise last_error
+        return set()
+
+    @staticmethod
+    def _get_legacy_relation_data(databag: MutableMapping) -> Optional[Set[str]]:
+        """Parse legacy raw-string CA transfer databags.
+
+        Some older providers send the CA PEM as a plain string in `ca` and an optional
+        JSON-encoded `chain` list without the v0 `certificate` field or JSON encoding
+        for every value. Accept that shape for backwards compatibility.
+        """
+        ca = databag.get("ca")
+        chain = databag.get("chain")
+        certificate = databag.get("certificate")
+        if ca is None and chain is None and certificate is None:
+            return None
+
+        certificates: List[str] = []
+        if isinstance(chain, str) and chain:
+            try:
+                parsed_chain = json.loads(chain)
+                if isinstance(parsed_chain, list):
+                    certificates.extend(cert for cert in parsed_chain if isinstance(cert, str) and cert)
+            except json.JSONDecodeError:
+                certificates.append(chain)
+
+        if isinstance(certificate, str) and certificate:
+            certificates.append(certificate)
+        if isinstance(ca, str) and ca:
+            certificates.insert(0, ca)
+
+        return set(certificates)
+
     def _get_relation_data(self, relation: Relation) -> Set[str]:
         """Get the given relation data."""
-        databag = relation.data[relation.app]
         try:
-            return ProviderApplicationData().load(databag).certificates
+            databag = relation.data[relation.app]
+            try:
+                certificates = ProviderApplicationData().load(databag).certificates
+            except DataValidationError:
+                return self._get_v0_relation_data(relation)
+
+            if certificates:
+                return certificates
+            return self._get_v0_relation_data(relation)
         except DataValidationError as e:
             logger.error(
                 (
@@ -448,11 +745,15 @@ class CertificateTransferRequires(Object):
             )
             return set()
 
-    def _get_relevant_relations(self, relation_id: Optional[int] = None) -> List[Relation]:
-        """Get the relevant relation if relation_id is given, all relations otherwise."""
+    def _get_active_relations(self, relation_id: Optional[int] = None) -> List[Relation]:
+        """Get the active relation if relation_id is given, all active relations otherwise."""
         if relation_id is not None:
             if relation := self.model.get_relation(
                 relation_name=self.relationship_name, relation_id=relation_id
             ):
                 return [relation]
-        return list(self.model.relations[self.relationship_name])
+        return [
+            relation
+            for relation in self.model.relations[self.relationship_name]
+            if relation.active
+        ]

--- a/src/charm.py
+++ b/src/charm.py
@@ -410,6 +410,12 @@ class JimmOperatorCharm(CharmBase):
             event.defer()
             return
 
+        # Publish SSH ingress requirements as soon as Pebble is reachable so
+        # Traefik can provision the per-unit TCP route even while other
+        # relations are still settling.
+        if self.unit.is_leader():
+            self.ingress_ssh.provide_ingress_requirements(port=self._ssh_port)
+
         # Wait for OAuth relations
         self.oauth.update_client_config(client_config=self._oauth_client_config)
         if not self.oauth.is_client_created():
@@ -478,11 +484,6 @@ class JimmOperatorCharm(CharmBase):
             event.defer()
             return
         self._write_jwks_files(container, jwks_config)
-
-        # Update the ssh ingress to reflect ssh port config changed. This is done in the leader unit
-        # because the ingress is per-unit and it doesn't support multiple units.
-        if self.unit.is_leader():
-            self.ingress_ssh.provide_ingress_requirements(port=self._ssh_port)
 
         config_values = {
             "BAKERY_PRIVATE_KEY": self.config.get("private-key", ""),

--- a/src/charm.py
+++ b/src/charm.py
@@ -781,7 +781,7 @@ class JimmOperatorCharm(CharmBase):
 
     @requires_state
     def _get_dns_name(self, event) -> str:
-        return self.ingress.url or str(self.config.get("dns-name", ""))
+        return (self.ingress.url or str(self.config.get("dns-name", ""))).rstrip("/")
 
     def _get_host_key(self) -> str:
         """

--- a/tests/integration/identity-bundle.yaml
+++ b/tests/integration/identity-bundle.yaml
@@ -67,8 +67,6 @@ applications:
     series: focal
     scale: 1
     trust: true
-    options:
-      external_hostname: traefik-admin.localhost
   traefik-public:
     charm: traefik-k8s
     channel: latest/stable
@@ -78,8 +76,6 @@ applications:
     series: focal
     scale: 1
     trust: true
-    options:
-      external_hostname: traefik-public.localhost
 relations:
   - [hydra:pg-database, postgresql-k8s:database]
   - [kratos:pg-database, postgresql-k8s:database]

--- a/tests/integration/identity-bundle.yaml
+++ b/tests/integration/identity-bundle.yaml
@@ -57,8 +57,8 @@ applications:
       plugin_btree_gin_enable: true
   self-signed-certificates:
     charm: self-signed-certificates
-    revision: 264
-    channel: latest/stable
+    revision: 588
+    channel: 1/stable
     scale: 1
   traefik-admin:
     charm: traefik-k8s
@@ -85,9 +85,15 @@ applications:
 relations:
   - [hydra:pg-database, postgresql-k8s:database]
   - [kratos:pg-database, postgresql-k8s:database]
+  - [kratos:hydra-endpoint-info, hydra:hydra-endpoint-info]
   - [kratos-external-idp-integrator:kratos-external-idp, kratos:kratos-external-idp]
   - [hydra:internal-route, traefik-admin:traefik-route]
   - [hydra:public-route, traefik-public:traefik-route]
   - [kratos:internal-route, traefik-admin:traefik-route]
   - [kratos:public-route, traefik-public:traefik-route]
   - [identity-platform-login-ui-operator:public-route, traefik-public:traefik-route]
+  - [traefik-public:certificates, self-signed-certificates:certificates]
+  - [identity-platform-login-ui-operator:hydra-endpoint-info, hydra:hydra-endpoint-info]
+  - [identity-platform-login-ui-operator:ui-endpoint-info, hydra:ui-endpoint-info]
+  - [identity-platform-login-ui-operator:ui-endpoint-info, kratos:ui-endpoint-info]
+  - [identity-platform-login-ui-operator:kratos-info, kratos:kratos-info]

--- a/tests/integration/identity-bundle.yaml
+++ b/tests/integration/identity-bundle.yaml
@@ -8,33 +8,37 @@ issues: https://github.com/canonical/iam-bundle/issues
 applications:
   hydra:
     charm: hydra
-    revision: 339
+    revision: 401
     resources:
-      oci-image: ghcr.io/canonical/hydra:2.3.0-canonical
+      oci-image: 281
     channel: latest/edge
     scale: 1
     series: jammy
     trust: true
+    options:
+      dev: true
   kratos:
     charm: kratos
-    revision: 500
+    revision: 571
     resources:
-      oci-image: ghcr.io/canonical/kratos:1.3.1
+      oci-image: 433
     channel: latest/edge
     scale: 1
     series: jammy
     trust: true
+    options:
+      enforce_mfa: false
   kratos-external-idp-integrator:
     charm: kratos-external-idp-integrator
     channel: latest/edge
-    revision: 245
+    revision: 299
     scale: 1
     series: jammy
   identity-platform-login-ui-operator:
     charm: identity-platform-login-ui-operator
-    revision: 146
+    revision: 203
     resources:
-      oci-image: ghcr.io/canonical/identity-platform-login-ui:v0.21.2
+      oci-image: 100
     channel: latest/edge
     scale: 1
     series: jammy
@@ -42,8 +46,9 @@ applications:
   postgresql-k8s:
     charm: postgresql-k8s
     channel: 14/stable
+    revision: 774
     resources:
-      postgresql-image: ghcr.io/canonical/charmed-postgresql@sha256:e2283194f7f8d9997fb06f0fd1ab0ec3938ce73ac001133bd8fd393ebe83acc7
+      postgresql-image: 184
     series: jammy
     scale: 1
     trust: true
@@ -52,40 +57,37 @@ applications:
       plugin_btree_gin_enable: true
   self-signed-certificates:
     charm: self-signed-certificates
-    revision: 155
+    revision: 264
     channel: latest/stable
     scale: 1
   traefik-admin:
     charm: traefik-k8s
     channel: latest/stable
-    revision: 176
+    revision: 298
     resources:
-      traefik-image: docker.io/ubuntu/traefik:2-22.04
+      traefik-image: 162
     series: focal
     scale: 1
     trust: true
+    options:
+      external_hostname: traefik-admin.localhost
   traefik-public:
     charm: traefik-k8s
     channel: latest/stable
-    revision: 176
+    revision: 298
     resources:
-      traefik-image: docker.io/ubuntu/traefik:2-22.04
+      traefik-image: 162
     series: focal
     scale: 1
     trust: true
+    options:
+      external_hostname: traefik-public.localhost
 relations:
   - [hydra:pg-database, postgresql-k8s:database]
   - [kratos:pg-database, postgresql-k8s:database]
-  - [kratos:hydra-endpoint-info, hydra:hydra-endpoint-info]
   - [kratos-external-idp-integrator:kratos-external-idp, kratos:kratos-external-idp]
-  - [hydra:admin-ingress, traefik-admin:ingress]
-  - [hydra:public-ingress, traefik-public:ingress]
-  - [kratos:admin-ingress, traefik-admin:ingress]
-  - [kratos:public-ingress, traefik-public:ingress]
-  - [identity-platform-login-ui-operator:ingress, traefik-public:ingress]
-  - [identity-platform-login-ui-operator:hydra-endpoint-info, hydra:hydra-endpoint-info]
-  - [identity-platform-login-ui-operator:ui-endpoint-info, hydra:ui-endpoint-info]
-  - [identity-platform-login-ui-operator:ui-endpoint-info, kratos:ui-endpoint-info]
-  - [identity-platform-login-ui-operator:kratos-info, kratos:kratos-info]
-  - [traefik-admin:certificates, self-signed-certificates:certificates]
-  - [traefik-public:certificates, self-signed-certificates:certificates]
+  - [hydra:internal-route, traefik-admin:traefik-route]
+  - [hydra:public-route, traefik-public:traefik-route]
+  - [kratos:internal-route, traefik-admin:traefik-route]
+  - [kratos:public-route, traefik-public:traefik-route]
+  - [identity-platform-login-ui-operator:public-route, traefik-public:traefik-route]

--- a/tests/integration/identity-bundle.yaml
+++ b/tests/integration/identity-bundle.yaml
@@ -15,8 +15,6 @@ applications:
     scale: 1
     series: jammy
     trust: true
-    options:
-      dev: true
   kratos:
     charm: kratos
     revision: 571

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -30,7 +30,6 @@ async def test_build_and_deploy(
     ops_test: OpsTest,
     charm: Path,
     hydra_app_name: str,
-    public_traefik_app_name: str,
     self_signed_certificates_app_name: str,
     ext_idp_service: ExternalIdpService,
 ) -> None:
@@ -38,9 +37,7 @@ async def test_build_and_deploy(
     # Build and deploy charm from local source folder
     # (Optionally build) and deploy charm from local source folder
 
-    await deploy_jimm(
-        ops_test, charm, hydra_app_name, public_traefik_app_name, self_signed_certificates_app_name, ext_idp_service
-    )
+    await deploy_jimm(ops_test, charm, hydra_app_name, self_signed_certificates_app_name, ext_idp_service)
 
 
 async def test_jimm_oauth_browser_login(

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -39,12 +39,7 @@ async def test_build_and_deploy(
     # (Optionally build) and deploy charm from local source folder
 
     await deploy_jimm(
-        ops_test,
-        charm,
-        hydra_app_name,
-        public_traefik_app_name,
-        self_signed_certificates_app_name,
-        ext_idp_service,
+        ops_test, charm, hydra_app_name, public_traefik_app_name, self_signed_certificates_app_name, ext_idp_service
     )
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -4,6 +4,7 @@
 
 import logging
 import re
+import secrets
 import socket
 from pathlib import Path
 from typing import Optional
@@ -12,9 +13,7 @@ import pytest
 from oauth_tools import (
     ExternalIdpService,
     access_application_login_page,
-    complete_auth_code_login,
     get_cookie_from_browser_by_name,
-    verify_page_loads,
 )
 from playwright.async_api import BrowserContext, Page
 from pytest_operator.plugin import OpsTest
@@ -22,6 +21,7 @@ from utils import deploy_jimm, get_jimm, get_jimm_address, get_service_external_
 
 pytest_plugins = ["oauth_tools.fixtures"]
 logger = logging.getLogger(__name__)
+LOCAL_TEST_USER_PASSWORD = "Password123"
 
 
 @pytest.mark.skip_if_deployed
@@ -53,18 +53,35 @@ async def test_jimm_oauth_browser_login(
     charm,
     page: Page,
     context: BrowserContext,
-    user_email: str,
-    ext_idp_service: ExternalIdpService,
 ):
     """Run a playwright test to perform the browser login flow and confirm the session cookie is valid."""
 
     jimm_address = await get_jimm_address(ops_test)
+    local_user_email = f"test-{secrets.token_hex(4)}@example.com"
 
     logger.info("running browser flow login test")
 
     await access_application_login_page(page=page, url=f"{jimm_address}/auth/login")
-    logger.info("completing external idp login")
-    await complete_auth_code_login(page=page, ops_test=ops_test, ext_idp_service=ext_idp_service)
+    logger.info("registering a local identity user")
+    await page.wait_for_url(re.compile(r"^https://[^/]+/ui/login.*$"))
+    async with page.expect_navigation(wait_until="domcontentloaded"):
+        await page.get_by_role("link", name="Register").click()
+    await page.get_by_role("textbox").fill(local_user_email)
+    await page.get_by_role("button", name="Sign up").click()
+    await page.get_by_placeholder("Your password").nth(0).fill(LOCAL_TEST_USER_PASSWORD)
+    await page.get_by_placeholder("Your password").nth(1).fill(LOCAL_TEST_USER_PASSWORD)
+    async with page.expect_navigation(wait_until="domcontentloaded"):
+        await page.get_by_role("button", name="Next").click()
+
+    logger.info("logging into JIMM with the registered user")
+    await access_application_login_page(page=page, url=f"{jimm_address}/auth/login")
+    await page.wait_for_url(re.compile(r"^https://[^/]+/ui/login.*$"))
+    await page.get_by_placeholder("Your Email").fill(local_user_email)
+    async with page.expect_navigation(wait_until="domcontentloaded"):
+        await page.get_by_role("button", name="Continue").click()
+    await page.get_by_placeholder("Your Password").fill(LOCAL_TEST_USER_PASSWORD)
+    async with page.expect_navigation(wait_until="domcontentloaded"):
+        await page.get_by_role("button", name="Sign in").click()
 
     logger.info("waiting for browser flow to return to JIMM")
     await page.wait_for_url(re.compile(rf"^{re.escape(jimm_address)}/(?:auth/callback|debug/info)(?:[/?#].*)?$"))
@@ -87,12 +104,8 @@ async def test_jimm_oauth_browser_login(
         cookies={"jimm-browser-session": jimm_session_cookie},
     )
     assert request.status_code == 200
-    assert request.json()["email"] == user_email
-
-    redirect_url = f"{jimm_address}/debug/info"
-    logger.info(f"loading authenticated JIMM page at {redirect_url}")
-    await page.goto(redirect_url)
-    await verify_page_loads(page=page, url=redirect_url)
+    assert request.json()["email"] == local_user_email
+    assert page.url.startswith(f"{jimm_address}/debug/info")
 
     # check ssh server is opened.
     # TODO(simonedutto): once the juju implementation is working, we should test it properly.

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -3,12 +3,12 @@
 # See LICENSE file for licensing details.
 
 import logging
+import re
 import socket
 from pathlib import Path
 from typing import Optional
 
 import pytest
-import requests
 from oauth_tools import (
     ExternalIdpService,
     access_application_login_page,
@@ -18,9 +18,7 @@ from oauth_tools import (
 )
 from playwright.async_api import BrowserContext, Page
 from pytest_operator.plugin import OpsTest
-from utils import deploy_jimm
-
-from tests.integration.utils import JIMM_ADDRESS
+from utils import deploy_jimm, get_jimm, get_jimm_address, get_service_external_ip
 
 pytest_plugins = ["oauth_tools.fixtures"]
 logger = logging.getLogger(__name__)
@@ -32,6 +30,7 @@ async def test_build_and_deploy(
     ops_test: OpsTest,
     charm: Path,
     hydra_app_name: str,
+    public_traefik_app_name: str,
     self_signed_certificates_app_name: str,
     ext_idp_service: ExternalIdpService,
 ) -> None:
@@ -39,7 +38,14 @@ async def test_build_and_deploy(
     # Build and deploy charm from local source folder
     # (Optionally build) and deploy charm from local source folder
 
-    await deploy_jimm(ops_test, charm, hydra_app_name, self_signed_certificates_app_name, ext_idp_service)
+    await deploy_jimm(
+        ops_test,
+        charm,
+        hydra_app_name,
+        public_traefik_app_name,
+        self_signed_certificates_app_name,
+        ext_idp_service,
+    )
 
 
 async def test_jimm_oauth_browser_login(
@@ -52,31 +58,47 @@ async def test_jimm_oauth_browser_login(
 ):
     """Run a playwright test to perform the browser login flow and confirm the session cookie is valid."""
 
+    jimm_address = await get_jimm_address(ops_test)
+
     logger.info("running browser flow login test")
 
-    await access_application_login_page(page=page, url=f"{JIMM_ADDRESS}/auth/login")
+    await access_application_login_page(page=page, url=f"{jimm_address}/auth/login")
     logger.info("completing external idp login")
     await complete_auth_code_login(page=page, ops_test=ops_test, ext_idp_service=ext_idp_service)
-    redirect_url = f"{JIMM_ADDRESS}/debug/info"
-    logger.info(f"verifying return to JIMM - expecting a final redirect to {redirect_url}")
-    await verify_page_loads(page=page, url=redirect_url)
+
+    logger.info("waiting for browser flow to return to JIMM")
+    await page.wait_for_url(re.compile(rf"^{re.escape(jimm_address)}/(?:auth/callback|debug/info)(?:[/?#].*)?$"))
 
     logger.info("verifying session cookie")
-    # Verifying that the login flow was successful is application specific.
-    # The test uses JIMM's /auth/whoami endpoint to verify the session cookie is valid
-    jimm_session_cookie = await get_cookie_from_browser_by_name(browser_context=context, name="jimm-browser-session")
-    request = requests.get(
-        f"{JIMM_ADDRESS}/auth/whoami",
-        headers={"Cookie": f"jimm-browser-session={jimm_session_cookie}"},
-        verify=False,
+    applicable_cookies = await context.cookies([f"{jimm_address}/auth/whoami"])
+    jimm_session_cookie = next(
+        (cookie["value"] for cookie in applicable_cookies if cookie["name"] == "jimm-browser-session"),
+        None,
+    )
+    if jimm_session_cookie is None:
+        jimm_session_cookie = await get_cookie_from_browser_by_name(
+            browser_context=context,
+            name="jimm-browser-session",
+        )
+    assert jimm_session_cookie is not None
+    request = get_jimm(
+        jimm_address,
+        "/auth/whoami",
+        cookies={"jimm-browser-session": jimm_session_cookie},
     )
     assert request.status_code == 200
     assert request.json()["email"] == user_email
 
+    redirect_url = f"{jimm_address}/debug/info"
+    logger.info(f"loading authenticated JIMM page at {redirect_url}")
+    await page.goto(redirect_url)
+    await verify_page_loads(page=page, url=redirect_url)
+
     # check ssh server is opened.
     # TODO(simonedutto): once the juju implementation is working, we should test it properly.
+    traefik_lb_ip = await get_service_external_ip(ops_test, "traefik-lb")
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    result = sock.connect_ex(("10.64.140.43", 17022))
+    result = sock.connect_ex((traefik_lb_ip, 17022))
     assert result == 0
 
 

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -5,12 +5,10 @@ import asyncio
 import json
 import logging
 from pathlib import Path
-from typing import Dict
 
 import requests
 import yaml
-from juju.unit import Unit
-from oauth_tools import ExternalIdpService
+from oauth_tools import ExternalIdpService, deploy_identity_bundle
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -18,16 +16,6 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = "juju-jimm-k8s"
 HTTP_INGRESS_APP_NAME = "traefik"
 HTTP_INGRESS_SERVICE_NAME = "traefik-lb"
-IDENTITY_PLATFORM_APPS = [
-    "hydra",
-    "kratos",
-    "identity-platform-login-ui-operator",
-    "postgresql-k8s",
-    "self-signed-certificates",
-    "traefik-admin",
-    "traefik-public",
-]
-IDENTITY_PLATFORM_ALL_APPS = IDENTITY_PLATFORM_APPS + ["kratos-external-idp-integrator"]
 JIMM_REQUEST_KWARGS = {"timeout": 30}
 
 
@@ -124,56 +112,6 @@ async def wait_for_service_external_ip(ops_test: OpsTest, service_name: str, tim
     raise RuntimeError(f"timed out waiting for service {service_name} external IP") from last_error
 
 
-async def wait_for_applications(
-    ops_test: OpsTest,
-    app_names: list[str],
-    timeout: int = 2000,
-) -> None:
-    """Wait for a set of applications to reach active using Juju CLI polling.
-
-    This avoids libjuju watcher churn and also tolerates transient hook failures
-    while applications are still converging.
-    """
-    deadline = asyncio.get_running_loop().time() + timeout
-    last_snapshot = ""
-
-    while True:
-        _, stdout, _ = await ops_test.juju("status", "--format=yaml")
-        status = yaml.safe_load(stdout)
-        applications = status.get("applications", {})
-
-        pending = []
-        snapshot_lines = []
-        for app_name in app_names:
-            app = applications.get(app_name)
-            if not app:
-                pending.append(app_name)
-                snapshot_lines.append(f"{app_name}: missing")
-                continue
-
-            app_status = app.get("application-status", {}).get("current")
-            units = app.get("units", {})
-            unit_states = [
-                (
-                    f"{unit_name}="
-                    f"{unit.get('workload-status', {}).get('current')}"
-                    f"/{unit.get('juju-status', {}).get('current')}"
-                )
-                for unit_name, unit in units.items()
-            ]
-            snapshot_lines.append(f"{app_name}: app={app_status} units={', '.join(unit_states) or 'none'}")
-            if app_status != "active":
-                pending.append(app_name)
-
-        if not pending:
-            return
-
-        last_snapshot = "\n".join(snapshot_lines)
-        if asyncio.get_running_loop().time() >= deadline:
-            raise RuntimeError("timed out waiting for applications to become active:\n" + last_snapshot)
-        await asyncio.sleep(5)
-
-
 async def get_traefik_address(
     ops_test: OpsTest,
     traefik_app_name: str,
@@ -196,53 +134,6 @@ async def get_traefik_address(
         return f"https://{ops_test.model_name}-{app_name}.{external_hostname}"
 
     return f"https://{external_ip}/{ops_test.model_name}-{app_name}"
-
-
-async def get_unit_by_name(unit_name: str, unit_index: str, unit_list: Dict[str, Unit]) -> Unit:
-    return unit_list.get("{unitname}/{unitindex}".format(unitname=unit_name, unitindex=unit_index))
-
-
-async def deploy_identity_bundle(
-    ops_test: OpsTest,
-    bundle_url: str,
-    ext_idp_service: ExternalIdpService,
-) -> None:
-    """Deploy and configure the identity bundle used by integration tests."""
-    await ops_test.run("juju", "deploy", bundle_url, "--trust")
-
-    logger.info("Waiting for the identity platform to deploy")
-    await wait_for_applications(ops_test, IDENTITY_PLATFORM_APPS)
-
-    admin_external_ip = await wait_for_service_external_ip(ops_test, "traefik-admin-lb")
-    public_external_ip = await wait_for_service_external_ip(ops_test, "traefik-public-lb")
-    await asyncio.gather(
-        ops_test.model.applications["traefik-admin"].set_config({"external_hostname": f"{admin_external_ip}.sslip.io"}),
-        ops_test.model.applications["traefik-public"].set_config(
-            {"external_hostname": f"{public_external_ip}.sslip.io"}
-        ),
-    )
-
-    await wait_for_applications(ops_test, IDENTITY_PLATFORM_APPS)
-
-    logger.info("Configuring the identity platform")
-    await ops_test.juju(
-        "config",
-        "kratos-external-idp-integrator",
-        f"client_id={ext_idp_service.client_id}",
-        f"client_secret={ext_idp_service.client_secret}",
-        "provider=generic",
-        f"issuer_url={ext_idp_service.issuer_url}",
-        "scope=profile email",
-        "provider_id=Dex",
-    )
-    await wait_for_applications(ops_test, IDENTITY_PLATFORM_ALL_APPS)
-
-    redirect_uri_action = (
-        await ops_test.model.applications["kratos-external-idp-integrator"].units[0].run_action("get-redirect-uri")
-    )
-    action_output = await redirect_uri_action.wait()
-    assert "redirect-uri" in action_output.results
-    ext_idp_service.update_redirect_uri(redirect_uri=action_output.results["redirect-uri"])
 
 
 async def deploy_jimm(
@@ -268,6 +159,16 @@ async def deploy_jimm(
     logger.info("deploying identity bundle")
     bundle_path = Path(__file__).parent / "identity-bundle.yaml"
     await deploy_identity_bundle(ops_test=ops_test, bundle_url=str(bundle_path), ext_idp_service=ext_idp_service)
+
+    logger.info("configuring identity bundle ingress hostnames")
+    admin_external_ip, public_external_ip = await asyncio.gather(
+        wait_for_service_external_ip(ops_test, "traefik-admin-lb"),
+        wait_for_service_external_ip(ops_test, "traefik-public-lb"),
+    )
+    await asyncio.gather(
+        ops_test.juju("config", "traefik-admin", f"external_hostname={admin_external_ip}.sslip.io"),
+        ops_test.juju("config", "traefik-public", f"external_hostname={public_external_ip}.sslip.io"),
+    )
 
     # Deploy the charm and wait for active/idle status
     logger.info("deploying charms")
@@ -302,12 +203,11 @@ async def deploy_jimm(
                 "traefik-k8s",
                 application_name="traefik",
                 channel="latest/stable",
-                config={"external_hostname": "traefik.localhost"},
             ),
         )
 
     logger.info("waiting for postgresql")
-    await wait_for_applications(ops_test, ["jimm-db"])
+    await ops_test.model.wait_for_idle(["jimm-db"], raise_on_blocked=False, status="active", timeout=2000)
 
     logger.info("adding custom ca cert relation")
     await ops_test.model.integrate("{}:receive-ca-cert".format(APP_NAME), self_signed_certificates_app_name)

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 import asyncio
+import json
 import logging
 from pathlib import Path
 from typing import Dict
@@ -15,7 +16,128 @@ from pytest_operator.plugin import OpsTest
 logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = "juju-jimm-k8s"
-JIMM_ADDRESS = "http://test.jimm.localhost"
+HTTP_INGRESS_APP_NAME = "traefik"
+HTTP_INGRESS_SERVICE_NAME = "traefik-lb"
+JIMM_REQUEST_KWARGS = {"timeout": 30}
+
+
+def get_jimm(jimm_address: str, url_path: str, **kwargs) -> requests.Response:
+    """Query the externally exposed JIMM endpoint."""
+    request_kwargs = {**JIMM_REQUEST_KWARGS, **kwargs}
+    if jimm_address.startswith("https://"):
+        request_kwargs.setdefault("verify", False)
+    return requests.get(f"{jimm_address.rstrip('/')}{url_path}", **request_kwargs)
+
+
+async def get_unit_data(ops_test: OpsTest, unit_name: str) -> dict:
+    _, stdout, _ = await ops_test.juju("show-unit", unit_name)
+    cmd_output = yaml.safe_load(stdout)
+    return cmd_output[unit_name]
+
+
+async def get_app_config(ops_test: OpsTest, app_name: str) -> dict:
+    _, stdout, _ = await ops_test.juju("config", app_name, "--format=yaml")
+    return yaml.safe_load(stdout)
+
+
+async def get_jimm_address(ops_test: OpsTest) -> str:
+    """Return the external HTTP URL for JIMM."""
+    data = await get_unit_data(ops_test, f"{APP_NAME}/0")
+    ingress_relation = next(
+        (integration for integration in data["relation-info"] if integration["endpoint"] == "ingress"),
+        None,
+    )
+    if not ingress_relation:
+        raise RuntimeError("JIMM ingress relation is not present")
+
+    ingress_data = ingress_relation.get("application-data", {}).get("ingress")
+    if ingress_data:
+        return json.loads(ingress_data)["url"].rstrip("/")
+
+    jimm_address = await get_traefik_address(ops_test, HTTP_INGRESS_APP_NAME, HTTP_INGRESS_SERVICE_NAME)
+    return jimm_address.rstrip("/")
+
+
+async def wait_for_jimm_address(ops_test: OpsTest, timeout: int = 300) -> str:
+    """Wait until Traefik publishes a reachable JIMM HTTP URL."""
+    last_error: Exception | None = None
+    attempts = max(1, timeout // 5)
+
+    for _ in range(attempts):
+        try:
+            jimm_address = await get_jimm_address(ops_test)
+            response = get_jimm(jimm_address, "/macaroons/publickey")
+            if response.status_code == 200:
+                return jimm_address
+            last_error = RuntimeError(
+                f"unexpected status from JIMM smoke check: {response.status_code}"
+            )
+        except (requests.RequestException, RuntimeError, KeyError, json.JSONDecodeError) as exc:
+            last_error = exc
+        await asyncio.sleep(5)
+
+    raise RuntimeError("timed out waiting for JIMM Traefik ingress") from last_error
+
+
+async def get_service_external_ip(ops_test: OpsTest, service_name: str) -> str:
+    """Return the external IP assigned to a service in the current model namespace."""
+    namespace = ops_test.model_name
+    if namespace is None:
+        raise RuntimeError("ops_test.model_name is not available")
+
+    _, stdout, _ = await ops_test.run(
+        "kubectl",
+        "get",
+        "svc",
+        "-n",
+        namespace,
+        service_name,
+        "-o",
+        "jsonpath={.status.loadBalancer.ingress[0].ip}",
+    )
+    external_ip = stdout.strip()
+    if not external_ip:
+        raise RuntimeError(f"service {service_name} does not have an external IP")
+    return external_ip
+
+
+async def wait_for_service_external_ip(ops_test: OpsTest, service_name: str, timeout: int = 300) -> str:
+    """Wait until a service in the current model namespace has an external IP."""
+    last_error: Exception | None = None
+    attempts = max(1, timeout // 5)
+
+    for _ in range(attempts):
+        try:
+            return await get_service_external_ip(ops_test, service_name)
+        except RuntimeError as exc:
+            last_error = exc
+        await asyncio.sleep(5)
+
+    raise RuntimeError(f"timed out waiting for service {service_name} external IP") from last_error
+
+
+async def get_traefik_address(
+    ops_test: OpsTest,
+    traefik_app_name: str,
+    service_name: str,
+    app_name: str = APP_NAME,
+) -> str:
+    """Build the expected Traefik ingress URL for an application."""
+    if ops_test.model_name is None:
+        raise RuntimeError("ops_test.model_name is not available")
+
+    config = await get_app_config(ops_test, traefik_app_name)
+    settings = config.get("settings", {})
+    routing_mode = settings.get("routing_mode", {}).get("value")
+    external_hostname = settings.get("external_hostname", {}).get("value")
+    external_ip = await get_service_external_ip(ops_test, service_name)
+
+    if routing_mode == "subdomain":
+        if not external_hostname:
+            external_hostname = f"{external_ip}.sslip.io"
+        return f"https://{ops_test.model_name}-{app_name}.{external_hostname}"
+
+    return f"https://{external_ip}/{ops_test.model_name}-{app_name}"
 
 
 async def get_unit_by_name(unit_name: str, unit_index: str, unit_list: Dict[str, Unit]) -> Unit:
@@ -26,6 +148,7 @@ async def deploy_jimm(
     ops_test: OpsTest,
     charm: Path,
     hydra_app_name: str,
+    public_traefik_app_name: str,
     self_signed_certificates_app_name: str,
     ext_idp_service: ExternalIdpService,
 ) -> None:
@@ -56,19 +179,15 @@ async def deploy_jimm(
                 application_name=APP_NAME,
                 config={
                     "uuid": "f4dec11e-e2b6-40bb-871a-cc38e958af49",
-                    "dns-name": "test.jimm.localhost",
+                    "dns-name": "",
                     "public-key": "izcYsQy3TePp6bLjqOo3IRPFvkQd2IKtyODGqC6SdFk=",
                     "private-key": "ly/dzsI9Nt/4JxUILQeAX79qZ4mygDiuYGqc2ZEiDEc=",
                     "postgres-secret-storage": True,
-                    # This is used by JIMM as the final redirect URL after doing the browser auth flow.
-                    # Since we don't deploy the dashboard for integration tests, we just set this parameter
-                    # to one of HTTP endpoints of JIMM.
-                    # "juju-dashboard-location": os.path.join(jimm_address.geturl(), "debug/info"),
-                    "juju-dashboard-location": f"{JIMM_ADDRESS}/debug/info",
+                    "secure-session-cookies": True,
+                    "juju-dashboard-location": "http://localhost/debug/info",
                 },
                 num_units=2,
             ),
-            ops_test.model.deploy("nginx-ingress-integrator", application_name="jimm-ingress", channel="latest/stable"),
             ops_test.model.deploy(
                 "postgresql-k8s",
                 application_name="jimm-db",
@@ -97,8 +216,8 @@ async def deploy_jimm(
     logger.info("adding custom ca cert relation")
     await ops_test.model.integrate("{}:receive-ca-cert".format(APP_NAME), self_signed_certificates_app_name)
 
-    logger.info("adding ingress relation")
-    await ops_test.model.integrate("{}:nginx-route".format(APP_NAME), "jimm-ingress")
+    logger.info("adding traefik certificate relation")
+    await ops_test.model.integrate(f"{HTTP_INGRESS_APP_NAME}:certificates", self_signed_certificates_app_name)
 
     logger.info("adding openfga postgresql relation")
     await ops_test.model.integrate("openfga:database", "jimm-db:database")
@@ -112,9 +231,37 @@ async def deploy_jimm(
     logger.info("adding oauth relation")
     await ops_test.model.integrate(f"{APP_NAME}:oauth", hydra_app_name)
 
+    logger.info("configuring dedicated traefik http ingress")
+    traefik_external_ip = await wait_for_service_external_ip(ops_test, HTTP_INGRESS_SERVICE_NAME)
+    await ops_test.juju(
+        "config",
+        HTTP_INGRESS_APP_NAME,
+        "routing_mode=subdomain",
+        f"external_hostname={traefik_external_ip}.sslip.io",
+    )
+
+    logger.info("adding traefik http relation")
+    await ops_test.model.integrate(f"{APP_NAME}:ingress", HTTP_INGRESS_APP_NAME)
+
     logger.info("adding traefik ssh relation")
-    await ops_test.model.integrate(f"{APP_NAME}:ingress-ssh", "traefik")
+    await ops_test.model.integrate(f"{APP_NAME}:ingress-ssh", HTTP_INGRESS_APP_NAME)
 
     await ops_test.model.wait_for_idle(timeout=2000)
-    macaroon_publickey = requests.get(f"{JIMM_ADDRESS}/macaroons/publickey")
+
+    expected_jimm_address = await get_traefik_address(
+        ops_test,
+        HTTP_INGRESS_APP_NAME,
+        HTTP_INGRESS_SERVICE_NAME,
+    )
+    logger.info("setting JIMM public URL to %s", expected_jimm_address)
+    await ops_test.juju(
+        "config",
+        APP_NAME,
+        f"dns-name={expected_jimm_address}",
+        f"juju-dashboard-location={expected_jimm_address}/debug/info",
+    )
+
+    await ops_test.model.wait_for_idle(timeout=2000)
+    jimm_address = await wait_for_jimm_address(ops_test)
+    macaroon_publickey = get_jimm(jimm_address, "/macaroons/publickey")
     assert macaroon_publickey.status_code == 200

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -224,11 +224,6 @@ async def deploy_identity_bundle(
 
     await wait_for_applications(ops_test, IDENTITY_PLATFORM_APPS)
 
-    # Hydra dev mode is only needed during the placeholder-host bootstrap.
-    await ops_test.juju("config", "hydra", "dev=false")
-
-    await wait_for_applications(ops_test, IDENTITY_PLATFORM_APPS)
-
     logger.info("Configuring the identity platform")
     await ops_test.juju(
         "config",

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -79,9 +79,7 @@ async def wait_for_jimm_address(ops_test: OpsTest, timeout: int = 300) -> str:
             response = get_jimm(jimm_address, "/macaroons/publickey")
             if response.status_code == 200:
                 return jimm_address
-            last_error = RuntimeError(
-                f"unexpected status from JIMM smoke check: {response.status_code}"
-            )
+            last_error = RuntimeError(f"unexpected status from JIMM smoke check: {response.status_code}")
         except (requests.RequestException, RuntimeError, KeyError, json.JSONDecodeError) as exc:
             last_error = exc
         await asyncio.sleep(5)
@@ -156,12 +154,14 @@ async def wait_for_applications(
             app_status = app.get("application-status", {}).get("current")
             units = app.get("units", {})
             unit_states = [
-                f"{unit_name}={unit.get('workload-status', {}).get('current')}/{unit.get('juju-status', {}).get('current')}"
+                (
+                    f"{unit_name}="
+                    f"{unit.get('workload-status', {}).get('current')}"
+                    f"/{unit.get('juju-status', {}).get('current')}"
+                )
                 for unit_name, unit in units.items()
             ]
-            snapshot_lines.append(
-                f"{app_name}: app={app_status} units={', '.join(unit_states) or 'none'}"
-            )
+            snapshot_lines.append(f"{app_name}: app={app_status} units={', '.join(unit_states) or 'none'}")
             if app_status != "active":
                 pending.append(app_name)
 
@@ -170,9 +170,7 @@ async def wait_for_applications(
 
         last_snapshot = "\n".join(snapshot_lines)
         if asyncio.get_running_loop().time() >= deadline:
-            raise RuntimeError(
-                "timed out waiting for applications to become active:\n" + last_snapshot
-            )
+            raise RuntimeError("timed out waiting for applications to become active:\n" + last_snapshot)
         await asyncio.sleep(5)
 
 
@@ -218,9 +216,7 @@ async def deploy_identity_bundle(
     admin_external_ip = await wait_for_service_external_ip(ops_test, "traefik-admin-lb")
     public_external_ip = await wait_for_service_external_ip(ops_test, "traefik-public-lb")
     await asyncio.gather(
-        ops_test.model.applications["traefik-admin"].set_config(
-            {"external_hostname": f"{admin_external_ip}.sslip.io"}
-        ),
+        ops_test.model.applications["traefik-admin"].set_config({"external_hostname": f"{admin_external_ip}.sslip.io"}),
         ops_test.model.applications["traefik-public"].set_config(
             {"external_hostname": f"{public_external_ip}.sslip.io"}
         ),
@@ -246,8 +242,8 @@ async def deploy_identity_bundle(
     )
     await wait_for_applications(ops_test, IDENTITY_PLATFORM_ALL_APPS)
 
-    redirect_uri_action = await ops_test.model.applications["kratos-external-idp-integrator"].units[0].run_action(
-        "get-redirect-uri"
+    redirect_uri_action = (
+        await ops_test.model.applications["kratos-external-idp-integrator"].units[0].run_action("get-redirect-uri")
     )
     action_output = await redirect_uri_action.wait()
     assert "redirect-uri" in action_output.results

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -5,14 +5,10 @@ import asyncio
 import json
 import logging
 from pathlib import Path
-from typing import Dict, cast
+from typing import Dict
 
 import requests
 import yaml
-from cryptography import x509
-from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.x509.oid import NameOID
 from juju.unit import Unit
 from oauth_tools import ExternalIdpService
 from pytest_operator.plugin import OpsTest
@@ -31,34 +27,7 @@ IDENTITY_PLATFORM_APPS = [
     "traefik-admin",
     "traefik-public",
 ]
-IDENTITY_FOUNDATIONAL_APPS = [
-    "postgresql-k8s",
-    "self-signed-certificates",
-    "traefik-admin",
-    "traefik-public",
-]
 IDENTITY_PLATFORM_ALL_APPS = IDENTITY_PLATFORM_APPS + ["kratos-external-idp-integrator"]
-IDENTITY_TRAEFIK_PLACEHOLDER_HOSTS = {
-    "traefik-admin": "traefik-admin.localhost",
-    "traefik-public": "traefik-public.localhost",
-}
-IDENTITY_ROUTE_DEPENDENT_RELATIONS = [
-    ("kratos:hydra-endpoint-info", "hydra:hydra-endpoint-info"),
-    (
-        "identity-platform-login-ui-operator:hydra-endpoint-info",
-        "hydra:hydra-endpoint-info",
-    ),
-    (
-        "identity-platform-login-ui-operator:ui-endpoint-info",
-        "hydra:ui-endpoint-info",
-    ),
-    (
-        "identity-platform-login-ui-operator:ui-endpoint-info",
-        "kratos:ui-endpoint-info",
-    ),
-    ("identity-platform-login-ui-operator:kratos-info", "kratos:kratos-info"),
-]
-SELF_SIGNED_CA_SECRET_LABEL = "ca-certificates"
 JIMM_REQUEST_KWARGS = {"timeout": 30}
 
 
@@ -79,109 +48,6 @@ async def get_unit_data(ops_test: OpsTest, unit_name: str) -> dict:
 async def get_app_config(ops_test: OpsTest, app_name: str) -> dict:
     _, stdout, _ = await ops_test.juju("config", app_name, "--format=yaml")
     return yaml.safe_load(stdout)
-
-
-async def list_secrets(ops_test: OpsTest) -> dict:
-    _, stdout, _ = await ops_test.juju("list-secrets", "--format=yaml")
-    return yaml.safe_load(stdout)
-
-
-async def show_secret(ops_test: OpsTest, secret_id: str) -> dict:
-    _, stdout, _ = await ops_test.juju("show-secret", secret_id, "--reveal", "--format=yaml")
-    return yaml.safe_load(stdout)
-
-
-async def get_ca_secret_content(ops_test: OpsTest) -> dict:
-    secrets = await list_secrets(ops_test)
-    secret_id = next(
-        secret_id
-        for secret_id, metadata in secrets.items()
-        if metadata.get("owner") == "self-signed-certificates"
-        and metadata.get("label") == SELF_SIGNED_CA_SECRET_LABEL
-    )
-    secret = await show_secret(ops_test, secret_id)
-    return secret[secret_id]["content"]
-
-
-def build_signed_certificate(
-    ca_certificate_pem: str,
-    ca_private_key_pem: str,
-    ca_private_key_password: str,
-    hostname: str,
-    extra_hostnames: list[str] | None = None,
-) -> tuple[str, str]:
-    """Generate a leaf certificate signed by the self-signed-certificates CA."""
-    ca_cert = x509.load_pem_x509_certificate(ca_certificate_pem.encode())
-    ca_key = cast(
-        rsa.RSAPrivateKey,
-        serialization.load_pem_private_key(
-        ca_private_key_pem.encode(),
-        password=ca_private_key_password.encode(),
-        ),
-    )
-    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    names = [hostname]
-    if extra_hostnames:
-        names.extend(extra_hostnames)
-    unique_names = sorted(set(names))
-
-    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, hostname)])
-    certificate = (
-        x509.CertificateBuilder()
-        .subject_name(subject)
-        .issuer_name(ca_cert.subject)
-        .public_key(private_key.public_key())
-        .serial_number(x509.random_serial_number())
-        .not_valid_before(ca_cert.not_valid_before_utc)
-        .not_valid_after(ca_cert.not_valid_after_utc)
-        .add_extension(
-            x509.SubjectAlternativeName([x509.DNSName(name) for name in unique_names]),
-            critical=False,
-        )
-        .sign(private_key=ca_key, algorithm=hashes.SHA256())
-    )
-
-    certificate_pem = certificate.public_bytes(serialization.Encoding.PEM).decode()
-    private_key_pem = private_key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.TraditionalOpenSSL,
-        encryption_algorithm=serialization.NoEncryption(),
-    ).decode()
-    return certificate_pem, private_key_pem
-
-
-async def configure_traefik_tls(
-    ops_test: OpsTest,
-    app_name: str,
-    hostname: str,
-    extra_hostnames: list[str] | None = None,
-) -> None:
-    """Configure a Traefik app with a CA-signed certificate for the given hostnames."""
-    ca_secret = await get_ca_secret_content(ops_test)
-    certificate_pem, private_key_pem = build_signed_certificate(
-        ca_certificate_pem=ca_secret["ca-certificate"],
-        ca_private_key_pem=ca_secret["private-key"],
-        ca_private_key_password=ca_secret["private-key-password"],
-        hostname=hostname,
-        extra_hostnames=extra_hostnames,
-    )
-    await ops_test.model.applications[app_name].set_config(
-        {
-            "external_hostname": hostname,
-            "tls-cert": certificate_pem,
-            "tls-key": private_key_pem,
-            "tls-ca": ca_secret["ca-certificate"],
-        }
-    )
-
-
-async def configure_traefik_http(
-    ops_test: OpsTest,
-    app_name: str,
-    hostname: str,
-) -> None:
-    """Configure a Traefik app to publish an HTTP host without TLS termination."""
-    await ops_test.model.applications[app_name].set_config({"external_hostname": hostname})
 
 
 async def get_jimm_address(ops_test: OpsTest) -> str:
@@ -346,29 +212,24 @@ async def deploy_identity_bundle(
     """Deploy and configure the identity bundle used by integration tests."""
     await ops_test.run("juju", "deploy", bundle_url, "--trust")
 
-    await asyncio.gather(
-        *[
-            ops_test.model.applications[app_name].set_config({"external_hostname": hostname})
-            for app_name, hostname in IDENTITY_TRAEFIK_PLACEHOLDER_HOSTS.items()
-        ]
-    )
-
-    logger.info("Waiting for foundational identity applications")
-    await wait_for_applications(ops_test, IDENTITY_FOUNDATIONAL_APPS)
+    logger.info("Waiting for the identity platform to deploy")
+    await wait_for_applications(ops_test, IDENTITY_PLATFORM_APPS)
 
     admin_external_ip = await wait_for_service_external_ip(ops_test, "traefik-admin-lb")
     public_external_ip = await wait_for_service_external_ip(ops_test, "traefik-public-lb")
     await asyncio.gather(
-        configure_traefik_http(ops_test, "traefik-admin", f"{admin_external_ip}.sslip.io"),
-        configure_traefik_tls(ops_test, "traefik-public", f"{public_external_ip}.sslip.io", ["traefik-public.localhost"]),
+        ops_test.model.applications["traefik-admin"].set_config(
+            {"external_hostname": f"{admin_external_ip}.sslip.io"}
+        ),
+        ops_test.model.applications["traefik-public"].set_config(
+            {"external_hostname": f"{public_external_ip}.sslip.io"}
+        ),
     )
+
+    await wait_for_applications(ops_test, IDENTITY_PLATFORM_APPS)
 
     # Hydra dev mode is only needed during the placeholder-host bootstrap.
     await ops_test.juju("config", "hydra", "dev=false")
-
-    logger.info("Adding route-dependent identity relations")
-    for endpoint_one, endpoint_two in IDENTITY_ROUTE_DEPENDENT_RELATIONS:
-        await ops_test.model.integrate(endpoint_one, endpoint_two)
 
     await wait_for_applications(ops_test, IDENTITY_PLATFORM_APPS)
 
@@ -473,14 +334,19 @@ async def deploy_jimm(
     logger.info("adding oauth relation")
     await ops_test.model.integrate(f"{APP_NAME}:oauth", hydra_app_name)
 
+    logger.info("adding traefik certificates relation")
+    await ops_test.model.integrate(
+        f"{HTTP_INGRESS_APP_NAME}:certificates",
+        f"{self_signed_certificates_app_name}:certificates",
+    )
+
     logger.info("configuring dedicated traefik http ingress")
     traefik_external_ip = await wait_for_service_external_ip(ops_test, HTTP_INGRESS_SERVICE_NAME)
-    await ops_test.model.applications[HTTP_INGRESS_APP_NAME].set_config({"routing_mode": "subdomain"})
-    await configure_traefik_tls(
-        ops_test,
-        HTTP_INGRESS_APP_NAME,
-        f"{traefik_external_ip}.sslip.io",
-        ["traefik.localhost"],
+    await ops_test.model.applications[HTTP_INGRESS_APP_NAME].set_config(
+        {
+            "routing_mode": "subdomain",
+            "external_hostname": f"{traefik_external_ip}.sslip.io",
+        }
     )
 
     logger.info("adding traefik http relation")

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -254,7 +254,6 @@ async def deploy_jimm(
     ops_test: OpsTest,
     charm: Path,
     hydra_app_name: str,
-    public_traefik_app_name: str,
     self_signed_certificates_app_name: str,
     ext_idp_service: ExternalIdpService,
 ) -> None:

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -5,12 +5,16 @@ import asyncio
 import json
 import logging
 from pathlib import Path
-from typing import Dict
+from typing import Dict, cast
 
 import requests
 import yaml
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
 from juju.unit import Unit
-from oauth_tools import ExternalIdpService, deploy_identity_bundle
+from oauth_tools import ExternalIdpService
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -18,6 +22,43 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = "juju-jimm-k8s"
 HTTP_INGRESS_APP_NAME = "traefik"
 HTTP_INGRESS_SERVICE_NAME = "traefik-lb"
+IDENTITY_PLATFORM_APPS = [
+    "hydra",
+    "kratos",
+    "identity-platform-login-ui-operator",
+    "postgresql-k8s",
+    "self-signed-certificates",
+    "traefik-admin",
+    "traefik-public",
+]
+IDENTITY_FOUNDATIONAL_APPS = [
+    "postgresql-k8s",
+    "self-signed-certificates",
+    "traefik-admin",
+    "traefik-public",
+]
+IDENTITY_PLATFORM_ALL_APPS = IDENTITY_PLATFORM_APPS + ["kratos-external-idp-integrator"]
+IDENTITY_TRAEFIK_PLACEHOLDER_HOSTS = {
+    "traefik-admin": "traefik-admin.localhost",
+    "traefik-public": "traefik-public.localhost",
+}
+IDENTITY_ROUTE_DEPENDENT_RELATIONS = [
+    ("kratos:hydra-endpoint-info", "hydra:hydra-endpoint-info"),
+    (
+        "identity-platform-login-ui-operator:hydra-endpoint-info",
+        "hydra:hydra-endpoint-info",
+    ),
+    (
+        "identity-platform-login-ui-operator:ui-endpoint-info",
+        "hydra:ui-endpoint-info",
+    ),
+    (
+        "identity-platform-login-ui-operator:ui-endpoint-info",
+        "kratos:ui-endpoint-info",
+    ),
+    ("identity-platform-login-ui-operator:kratos-info", "kratos:kratos-info"),
+]
+SELF_SIGNED_CA_SECRET_LABEL = "ca-certificates"
 JIMM_REQUEST_KWARGS = {"timeout": 30}
 
 
@@ -38,6 +79,109 @@ async def get_unit_data(ops_test: OpsTest, unit_name: str) -> dict:
 async def get_app_config(ops_test: OpsTest, app_name: str) -> dict:
     _, stdout, _ = await ops_test.juju("config", app_name, "--format=yaml")
     return yaml.safe_load(stdout)
+
+
+async def list_secrets(ops_test: OpsTest) -> dict:
+    _, stdout, _ = await ops_test.juju("list-secrets", "--format=yaml")
+    return yaml.safe_load(stdout)
+
+
+async def show_secret(ops_test: OpsTest, secret_id: str) -> dict:
+    _, stdout, _ = await ops_test.juju("show-secret", secret_id, "--reveal", "--format=yaml")
+    return yaml.safe_load(stdout)
+
+
+async def get_ca_secret_content(ops_test: OpsTest) -> dict:
+    secrets = await list_secrets(ops_test)
+    secret_id = next(
+        secret_id
+        for secret_id, metadata in secrets.items()
+        if metadata.get("owner") == "self-signed-certificates"
+        and metadata.get("label") == SELF_SIGNED_CA_SECRET_LABEL
+    )
+    secret = await show_secret(ops_test, secret_id)
+    return secret[secret_id]["content"]
+
+
+def build_signed_certificate(
+    ca_certificate_pem: str,
+    ca_private_key_pem: str,
+    ca_private_key_password: str,
+    hostname: str,
+    extra_hostnames: list[str] | None = None,
+) -> tuple[str, str]:
+    """Generate a leaf certificate signed by the self-signed-certificates CA."""
+    ca_cert = x509.load_pem_x509_certificate(ca_certificate_pem.encode())
+    ca_key = cast(
+        rsa.RSAPrivateKey,
+        serialization.load_pem_private_key(
+        ca_private_key_pem.encode(),
+        password=ca_private_key_password.encode(),
+        ),
+    )
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    names = [hostname]
+    if extra_hostnames:
+        names.extend(extra_hostnames)
+    unique_names = sorted(set(names))
+
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, hostname)])
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(ca_cert.subject)
+        .public_key(private_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(ca_cert.not_valid_before_utc)
+        .not_valid_after(ca_cert.not_valid_after_utc)
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(name) for name in unique_names]),
+            critical=False,
+        )
+        .sign(private_key=ca_key, algorithm=hashes.SHA256())
+    )
+
+    certificate_pem = certificate.public_bytes(serialization.Encoding.PEM).decode()
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    return certificate_pem, private_key_pem
+
+
+async def configure_traefik_tls(
+    ops_test: OpsTest,
+    app_name: str,
+    hostname: str,
+    extra_hostnames: list[str] | None = None,
+) -> None:
+    """Configure a Traefik app with a CA-signed certificate for the given hostnames."""
+    ca_secret = await get_ca_secret_content(ops_test)
+    certificate_pem, private_key_pem = build_signed_certificate(
+        ca_certificate_pem=ca_secret["ca-certificate"],
+        ca_private_key_pem=ca_secret["private-key"],
+        ca_private_key_password=ca_secret["private-key-password"],
+        hostname=hostname,
+        extra_hostnames=extra_hostnames,
+    )
+    await ops_test.model.applications[app_name].set_config(
+        {
+            "external_hostname": hostname,
+            "tls-cert": certificate_pem,
+            "tls-key": private_key_pem,
+            "tls-ca": ca_secret["ca-certificate"],
+        }
+    )
+
+
+async def configure_traefik_http(
+    ops_test: OpsTest,
+    app_name: str,
+    hostname: str,
+) -> None:
+    """Configure a Traefik app to publish an HTTP host without TLS termination."""
+    await ops_test.model.applications[app_name].set_config({"external_hostname": hostname})
 
 
 async def get_jimm_address(ops_test: OpsTest) -> str:
@@ -116,6 +260,56 @@ async def wait_for_service_external_ip(ops_test: OpsTest, service_name: str, tim
     raise RuntimeError(f"timed out waiting for service {service_name} external IP") from last_error
 
 
+async def wait_for_applications(
+    ops_test: OpsTest,
+    app_names: list[str],
+    timeout: int = 2000,
+) -> None:
+    """Wait for a set of applications to reach active using Juju CLI polling.
+
+    This avoids libjuju watcher churn and also tolerates transient hook failures
+    while applications are still converging.
+    """
+    deadline = asyncio.get_running_loop().time() + timeout
+    last_snapshot = ""
+
+    while True:
+        _, stdout, _ = await ops_test.juju("status", "--format=yaml")
+        status = yaml.safe_load(stdout)
+        applications = status.get("applications", {})
+
+        pending = []
+        snapshot_lines = []
+        for app_name in app_names:
+            app = applications.get(app_name)
+            if not app:
+                pending.append(app_name)
+                snapshot_lines.append(f"{app_name}: missing")
+                continue
+
+            app_status = app.get("application-status", {}).get("current")
+            units = app.get("units", {})
+            unit_states = [
+                f"{unit_name}={unit.get('workload-status', {}).get('current')}/{unit.get('juju-status', {}).get('current')}"
+                for unit_name, unit in units.items()
+            ]
+            snapshot_lines.append(
+                f"{app_name}: app={app_status} units={', '.join(unit_states) or 'none'}"
+            )
+            if app_status != "active":
+                pending.append(app_name)
+
+        if not pending:
+            return
+
+        last_snapshot = "\n".join(snapshot_lines)
+        if asyncio.get_running_loop().time() >= deadline:
+            raise RuntimeError(
+                "timed out waiting for applications to become active:\n" + last_snapshot
+            )
+        await asyncio.sleep(5)
+
+
 async def get_traefik_address(
     ops_test: OpsTest,
     traefik_app_name: str,
@@ -142,6 +336,61 @@ async def get_traefik_address(
 
 async def get_unit_by_name(unit_name: str, unit_index: str, unit_list: Dict[str, Unit]) -> Unit:
     return unit_list.get("{unitname}/{unitindex}".format(unitname=unit_name, unitindex=unit_index))
+
+
+async def deploy_identity_bundle(
+    ops_test: OpsTest,
+    bundle_url: str,
+    ext_idp_service: ExternalIdpService,
+) -> None:
+    """Deploy and configure the identity bundle used by integration tests."""
+    await ops_test.run("juju", "deploy", bundle_url, "--trust")
+
+    await asyncio.gather(
+        *[
+            ops_test.model.applications[app_name].set_config({"external_hostname": hostname})
+            for app_name, hostname in IDENTITY_TRAEFIK_PLACEHOLDER_HOSTS.items()
+        ]
+    )
+
+    logger.info("Waiting for foundational identity applications")
+    await wait_for_applications(ops_test, IDENTITY_FOUNDATIONAL_APPS)
+
+    admin_external_ip = await wait_for_service_external_ip(ops_test, "traefik-admin-lb")
+    public_external_ip = await wait_for_service_external_ip(ops_test, "traefik-public-lb")
+    await asyncio.gather(
+        configure_traefik_http(ops_test, "traefik-admin", f"{admin_external_ip}.sslip.io"),
+        configure_traefik_tls(ops_test, "traefik-public", f"{public_external_ip}.sslip.io", ["traefik-public.localhost"]),
+    )
+
+    # Hydra dev mode is only needed during the placeholder-host bootstrap.
+    await ops_test.juju("config", "hydra", "dev=false")
+
+    logger.info("Adding route-dependent identity relations")
+    for endpoint_one, endpoint_two in IDENTITY_ROUTE_DEPENDENT_RELATIONS:
+        await ops_test.model.integrate(endpoint_one, endpoint_two)
+
+    await wait_for_applications(ops_test, IDENTITY_PLATFORM_APPS)
+
+    logger.info("Configuring the identity platform")
+    await ops_test.juju(
+        "config",
+        "kratos-external-idp-integrator",
+        f"client_id={ext_idp_service.client_id}",
+        f"client_secret={ext_idp_service.client_secret}",
+        "provider=generic",
+        f"issuer_url={ext_idp_service.issuer_url}",
+        "scope=profile email",
+        "provider_id=Dex",
+    )
+    await wait_for_applications(ops_test, IDENTITY_PLATFORM_ALL_APPS)
+
+    redirect_uri_action = await ops_test.model.applications["kratos-external-idp-integrator"].units[0].run_action(
+        "get-redirect-uri"
+    )
+    action_output = await redirect_uri_action.wait()
+    assert "redirect-uri" in action_output.results
+    ext_idp_service.update_redirect_uri(redirect_uri=action_output.results["redirect-uri"])
 
 
 async def deploy_jimm(
@@ -186,7 +435,7 @@ async def deploy_jimm(
                     "secure-session-cookies": True,
                     "juju-dashboard-location": "http://localhost/debug/info",
                 },
-                num_units=2,
+                num_units=1,
             ),
             ops_test.model.deploy(
                 "postgresql-k8s",
@@ -202,22 +451,15 @@ async def deploy_jimm(
                 "traefik-k8s",
                 application_name="traefik",
                 channel="latest/stable",
+                config={"external_hostname": "traefik.localhost"},
             ),
         )
 
     logger.info("waiting for postgresql")
-    await ops_test.model.wait_for_idle(
-        apps=["jimm-db"],
-        status="active",
-        raise_on_blocked=True,
-        timeout=2000,
-    )
+    await wait_for_applications(ops_test, ["jimm-db"])
 
     logger.info("adding custom ca cert relation")
     await ops_test.model.integrate("{}:receive-ca-cert".format(APP_NAME), self_signed_certificates_app_name)
-
-    logger.info("adding traefik certificate relation")
-    await ops_test.model.integrate(f"{HTTP_INGRESS_APP_NAME}:certificates", self_signed_certificates_app_name)
 
     logger.info("adding openfga postgresql relation")
     await ops_test.model.integrate("openfga:database", "jimm-db:database")
@@ -233,11 +475,12 @@ async def deploy_jimm(
 
     logger.info("configuring dedicated traefik http ingress")
     traefik_external_ip = await wait_for_service_external_ip(ops_test, HTTP_INGRESS_SERVICE_NAME)
-    await ops_test.juju(
-        "config",
+    await ops_test.model.applications[HTTP_INGRESS_APP_NAME].set_config({"routing_mode": "subdomain"})
+    await configure_traefik_tls(
+        ops_test,
         HTTP_INGRESS_APP_NAME,
-        "routing_mode=subdomain",
-        f"external_hostname={traefik_external_ip}.sslip.io",
+        f"{traefik_external_ip}.sslip.io",
+        ["traefik.localhost"],
     )
 
     logger.info("adding traefik http relation")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -567,6 +567,21 @@ class TestCharm(TestCase):
         self.assertEqual(self.harness.charm.unit.status.name, BlockedStatus.name)
         self.assertEqual(self.harness.charm.unit.status.message, "Waiting for OAuth relation")
 
+    def test_ssh_ingress_is_published_before_oauth_ready(self):
+        self.harness.update_config(MINIMAL_CONFIG)
+        self.harness.remove_relation(self.oauth_rel_id)
+        container = self.harness.model.unit.get_container("jimm")
+
+        with mock.patch.object(
+            self.harness.charm.ingress_ssh,
+            "provide_ingress_requirements",
+        ) as provide_requirements:
+            self.harness.charm.on.jimm_pebble_ready.emit(container)
+
+        provide_requirements.assert_called_once_with(port=self.harness.charm._ssh_port)
+        self.assertEqual(self.harness.charm.unit.status.name, BlockedStatus.name)
+        self.assertEqual(self.harness.charm.unit.status.message, "Waiting for OAuth relation")
+
     def test_app_enters_block_state_if_oauth_relation_not_ready(self):
         self.harness.update_config(MINIMAL_CONFIG)
         self.harness.remove_relation(self.oauth_rel_id)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -550,6 +550,10 @@ class TestCharm(TestCase):
         oauth_client = self.harness.charm._oauth_client_config
         self.assertEqual(oauth_client.redirect_uri, "https://jimm.com/some/path/auth/callback")
 
+        self.harness.update_config({"dns-name": "https://jimm.com/"})
+        oauth_client = self.harness.charm._oauth_client_config
+        self.assertEqual(oauth_client.redirect_uri, "https://jimm.com/auth/callback")
+
     def test_app_enters_block_states_if_oauth_relation_removed(self):
         self.harness.update_config(MINIMAL_CONFIG)
         self.harness.remove_relation(self.oauth_rel_id)


### PR DESCRIPTION
## Description

This change updates the charm lib `certificate_transfer.py` used by the JIMM charm for relating to any charm that provides certs to our charm. This requires a further set of updates to the charms used in our tests, specifically to the Canonical identity platform charms and a move away from the `nginx-ingress-integrator` charm in favour or Traefik, as we use in production. The identity-bundle.yaml file defines charm and resource revisions to use for the deployment of the identity bundle and these have been updated to the latest revisions.

Many of the changes to the test utils are around fetching the ingress address from Traefik and removing some usages of the oauth helper library.

The main motivation for this update was a problem in JIMM's tutorial. When using the latest version of the `self-signed-certificates` charm, we encounter an incompatibility since JIMM was using an outdated version of the cert-transfer interface while the latest `self-signed-certificates` charm requires a newer version.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests