### PR TITLE
fix: adjust dashboard controller url

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -11,7 +11,7 @@ from base64 import b64encode
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin, urlparse, urlunparse
 from uuid import uuid4
 
 from charms.certificate_transfer_interface.v1.certificate_transfer import (
@@ -598,7 +598,7 @@ class JimmOperatorCharm(CharmBase):
         if dashboard_relation and self.unit.is_leader():
             dashboard_relation.data[self.app].update(
                 {
-                    "controller-url": "wss://{}".format(dns_name),
+                    "controller-url": self._controller_url(dns_name),
                     "is-juju": str(False),
                 }
             )
@@ -709,10 +709,24 @@ class JimmOperatorCharm(CharmBase):
 
         event.relation.data[self.app].update(
             {
-                "controller-url": "wss://{}".format(dns_name),
+                "controller-url": self._controller_url(dns_name),
                 "is-juju": str(False),
             }
         )
+
+    def _controller_url(self, dns_name: str) -> str:
+        parsed = urlparse(dns_name)
+        if not parsed.scheme:
+            return f"wss://{dns_name}"
+
+        websocket_scheme = {
+            "http": "ws",
+            "https": "wss",
+            "ws": "ws",
+            "wss": "wss",
+        }.get(parsed.scheme, "wss")
+
+        return urlunparse(parsed._replace(scheme=websocket_scheme))
 
     @requires_state_setter
     def _on_database_event(self, event: DatabaseRequiresEvent) -> None:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -696,6 +696,26 @@ class TestCharm(TestCase):
         )
         self.assertEqual(data["is-juju"], "False")
 
+    def test_dashboard_relation_joined_with_scheme(self):
+        self.start_minimal_jimm()
+
+        with mock.patch.object(
+            type(self.harness.charm.ingress),
+            "url",
+            new_callable=mock.PropertyMock,
+            return_value="https://jimm.workshop/jimm-jimm",
+        ):
+            id = self.harness.add_relation("dashboard", "juju-dashboard")
+            self.harness.add_relation_unit(id, "juju-dashboard/0")
+            data = self.harness.get_relation_data(id, "juju-jimm-k8s")
+
+            self.assertTrue(data)
+            self.assertEqual(
+                data["controller-url"],
+                "wss://jimm.workshop/jimm-jimm",
+            )
+            self.assertEqual(data["is-juju"], "False")
+
     def test_vault_relation_joined(self):
         self.start_minimal_jimm()
 


### PR DESCRIPTION
## Description

There was an issue reported when relating JIMM to the dashboard charm, where the application data was as below,
```
    application-data:
      controller-url: wss://https://jimm.workshop/jimm-jimm
      is-juju: "False"
```
To address this, parse the URL before setting the controller URL so that we can replace the scheme properly.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests
