### PR TITLE
ci: update publish workflow for v4 and merge forward v3

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,10 +1,10 @@
-name: Release to v3/edge
+name: Release to v4/edge
 
 on:
   workflow_dispatch:
   push:
     branches:
-      - v3
+      - v4
 
 # Note this workflow requires a Github secret to provide auth against charmhub.
 # This can be generated with the following command (ttl=6 months)
@@ -40,4 +40,4 @@ jobs:
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: "3/edge"
+          channel: "4/edge"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -96,4 +96,4 @@ resources:
   jimm-image:
     type: oci-image
     description: OCI image for JIMM.
-    upstream-source: ghcr.io/canonical/jimm:v3.4.0
+    upstream-source: ghcr.io/canonical/jimm:v3.4.2

--- a/src/charm.py
+++ b/src/charm.py
@@ -11,7 +11,7 @@ from base64 import b64encode
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin, urlparse, urlunparse
 from uuid import uuid4
 
 from charms.certificate_transfer_interface.v1.certificate_transfer import (
@@ -598,7 +598,7 @@ class JimmOperatorCharm(CharmBase):
         if dashboard_relation and self.unit.is_leader():
             dashboard_relation.data[self.app].update(
                 {
-                    "controller-url": "wss://{}".format(dns_name),
+                    "controller-url": self._controller_url(dns_name),
                     "is-juju": str(False),
                 }
             )
@@ -709,10 +709,24 @@ class JimmOperatorCharm(CharmBase):
 
         event.relation.data[self.app].update(
             {
-                "controller-url": "wss://{}".format(dns_name),
+                "controller-url": self._controller_url(dns_name),
                 "is-juju": str(False),
             }
         )
+
+    def _controller_url(self, dns_name: str) -> str:
+        parsed = urlparse(dns_name)
+        if not parsed.scheme:
+            return f"wss://{dns_name}"
+
+        websocket_scheme = {
+            "http": "ws",
+            "https": "wss",
+            "ws": "ws",
+            "wss": "wss",
+        }.get(parsed.scheme, "wss")
+
+        return urlunparse(parsed._replace(scheme=websocket_scheme))
 
     @requires_state_setter
     def _on_database_event(self, event: DatabaseRequiresEvent) -> None:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -696,6 +696,26 @@ class TestCharm(TestCase):
         )
         self.assertEqual(data["is-juju"], "False")
 
+    def test_dashboard_relation_joined_with_scheme(self):
+        self.start_minimal_jimm()
+
+        with mock.patch.object(
+            type(self.harness.charm.ingress),
+            "url",
+            new_callable=mock.PropertyMock,
+            return_value="https://jimm.workshop/jimm-jimm",
+        ):
+            id = self.harness.add_relation("dashboard", "juju-dashboard")
+            self.harness.add_relation_unit(id, "juju-dashboard/0")
+            data = self.harness.get_relation_data(id, "juju-jimm-k8s")
+
+            self.assertTrue(data)
+            self.assertEqual(
+                data["controller-url"],
+                "wss://jimm.workshop/jimm-jimm",
+            )
+            self.assertEqual(data["is-juju"], "False")
+
     def test_vault_relation_joined(self):
         self.start_minimal_jimm()
 


### PR DESCRIPTION
## Description

This PR merges forward the `v3` branch changes to `v4` and updates our `publish` workflow to release to the 4/edge channel. The new track `4` has been requested in https://discourse.charmhub.io/t/create-new-track-for-juju-jimm-k8s-charm/20650 so we should wait for the track to be created before landing this change.

Fixes [JUJU-10048](https://warthogs.atlassian.net/browse/JUJU-10048)


[JUJU-10048]: https://warthogs.atlassian.net/browse/JUJU-10048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ